### PR TITLE
Test on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![Python Badge](https://img.shields.io/badge/Python-≥3.11-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
+[![Python Badge](https://img.shields.io/badge/Python-3.11-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
 [![License Badge](https://img.shields.io/badge/License-Apache%202.0-green.svg?style=for-the-badge&logo=apache&logoColor=white)](https://github.com/prefix-dev/pgsql-search/blob/main/LICENSE)
 [![Pixi Badge](https://img.shields.io/badge/🔌_Powered_by-Pixi-yellow?style=for-the-badge)](https://pixi.sh)
+[![Tested on](https://img.shields.io/badge/✓_Tested_on-Linux_•_macOS-purple?style=for-the-badge)](https://github.com/dnth/DEIMKit)
 
 
 <div align="center">

--- a/scripts/quickstart.py
+++ b/scripts/quickstart.py
@@ -30,7 +30,7 @@ conf = Config.from_model_name("deim_hgnetv2_n")
 
 conf = configure_dataset(
     config=conf,
-    image_size=(640, 640),
+    image_size=(320, 320),
     train_ann_file="./data/coco8-converted/train_coco.json",
     train_img_folder="./data/coco8-converted",
     val_ann_file="./data/coco8-converted/val_coco.json",


### PR DESCRIPTION
- Updated Python badge in README to specify version 3.11.
- Added a badge indicating testing on Linux and macOS.
- Changed image size configuration in quickstart.py from (640, 640) to (320, 320).
- Improved device configuration in Trainer class to set device parameters and disable multiprocessing for CPU training, enhancing logging for better clarity on device usage.