### PR TITLE
Standardize Input Size Parameter and Add Progressive Training Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ python scripts/live_inference.py
     --model model.onnx          # Path to the ONNX model file
     --webcam                    # Use webcam as input source
     --classes classes.txt       # Path to the classes file with each name on a new row
-    --video-width 720           # Input size for the model
+    --inference-size 720        # Input size for the model
     --provider tensorrt         # Execution provider (cpu/cuda/tensorrt)
     --threshold 0.3             # Detection confidence threshold
 ```
@@ -385,7 +385,7 @@ python scripts/live_inference.py
     --model model.onnx           # Path to the ONNX model file
     --video video.mp4            # Path to the input video file
     --classes classes.txt        # Path to the classes file with each name on a new row
-    --video-width 320            # Input size for the model
+    --inference-size 320         # Input size for the model (renamed from --video-width)
     --provider cpu               # Execution provider (cpu/cuda/tensorrt)
     --threshold 0.3              # Detection confidence threshold
 ```
@@ -422,7 +422,7 @@ The following is a demo of image inference
 >     --onnx model.onnx           
 >     --webcam                    
 >     --class-names classes.txt   
->     --input-size 320            
+>     --inference-size 320            
 > ```
 > Under the hood, this automatically pull in the `onnxruntime-gpu` package into the `cuda` environment and use the GPU for inference!
 >
@@ -456,7 +456,7 @@ pixi run -e cpu train-model
 
 Run live inference
 ```bash
-pixi run -e cuda live-inference --onnx model.onnx --webcam --provider cuda --class-names classes.txt --input-size 640
+pixi run -e cuda live-inference --onnx model.onnx --webcam --provider cuda --class-names classes.txt --inference-size 640
 ```
 
 > [!TIP]
@@ -468,7 +468,7 @@ pixi run -e cuda live-inference --onnx model.onnx --webcam --provider cuda --cla
 > ```
 
 ```bash
-pixi run -e cpu live-inference --onnx model.onnx --input video.mp4 --class-names classes.txt --input-size 320
+pixi run -e cpu live-inference --onnx model.onnx --input video.mp4 --class-names classes.txt --inference-size 320
 ```
 
 Launch Gradio app

--- a/nbs/progressive-resising.ipynb
+++ b/nbs/progressive-resising.ipynb
@@ -2564,6 +2564,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train at 640px for 30 epochs "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
@@ -4280,6 +4287,1611 @@
     "    checkpoint_path=\"/home/dnth/Desktop/DEIMKit/nbs/outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\",\n",
     "    output_path=\"/home/dnth/Desktop/DEIMKit/nbs/outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.onnx\"\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train at 640px for 30 epochs with model trained at smaller sizes image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 21:01:56.724\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.DFINETransformer.num_queries' to: 100\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:56.725\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.PostProcessor.num_top_queries' to: 100\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:56.725\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.HGNetv2.pretrained' to: True\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:56.725\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.HGNetv2.freeze_at' to: 0\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:56.771\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_init_process_group\u001b[0m:\u001b[36m60\u001b[0m - \u001b[1mInitializing process group for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:56.773\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_init_process_group\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mProcess group initialized successfully\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:56.774\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_checkpoint\u001b[0m:\u001b[36m624\u001b[0m - \u001b[1mLoading checkpoint from outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:56.985\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m152\u001b[0m - \u001b[1mDisabling sync_bn and find_unused_parameters for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:56.986\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m164\u001b[0m - \u001b[1mSet device in config: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:56.986\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m174\u001b[0m - \u001b[1mInitializing solver for task: detection\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded stage1 B0 HGNetV2 from local file.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/dnth/Desktop/DEIMKit/src/deimkit/engine/core/workspace.py:180: FutureWarning: `torch.cuda.amp.GradScaler(args...)` is deprecated. Please use `torch.amp.GradScaler('cuda', args...)` instead.\n",
+      "  return module(**module_kwargs)\n",
+      "\u001b[32m2025-04-03 21:01:57.515\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m201\u001b[0m - \u001b[1mTraining setup complete. Output directory: outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.516\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m203\u001b[0m - \u001b[1mSaving config to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing/config.yml\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.556\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m642\u001b[0m - \u001b[33m\u001b[1mShape mismatch, loading compatible parameters only: Error(s) in loading state_dict for DistributedDataParallel:\n",
+      "\tsize mismatch for module.decoder.anchors: copying a param with shape torch.Size([1, 2100, 4]) from checkpoint, the shape in current model is torch.Size([1, 8400, 4]).\n",
+      "\tsize mismatch for module.decoder.valid_mask: copying a param with shape torch.Size([1, 2100, 1]) from checkpoint, the shape in current model is torch.Size([1, 8400, 1]).\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.603\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m649\u001b[0m - \u001b[1mLoaded parameters with matching shapes\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.637\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_checkpoint\u001b[0m:\u001b[36m659\u001b[0m - \u001b[1mAttempting to load EMA parameters with matching shapes...\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.668\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m642\u001b[0m - \u001b[33m\u001b[1mShape mismatch, loading compatible parameters only: Error(s) in loading state_dict for DEIM:\n",
+      "\tsize mismatch for decoder.anchors: copying a param with shape torch.Size([1, 2100, 4]) from checkpoint, the shape in current model is torch.Size([1, 8400, 4]).\n",
+      "\tsize mismatch for decoder.valid_mask: copying a param with shape torch.Size([1, 2100, 1]) from checkpoint, the shape in current model is torch.Size([1, 8400, 1]).\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial lr: [0.0002, 0.0004, 0.0004]\n",
+      "building train_dataloader with batch_size=16...\n",
+      "     ### Transform @Mosaic ###    \n",
+      "     ### Transform @RandomPhotometricDistort ###    \n",
+      "     ### Transform @RandomZoomOut ###    \n",
+      "     ### Transform @RandomIoUCrop ###    \n",
+      "     ### Transform @SanitizeBoundingBoxes ###    \n",
+      "     ### Transform @RandomHorizontalFlip ###    \n",
+      "     ### Transform @Resize ###    \n",
+      "     ### Transform @SanitizeBoundingBoxes ###    \n",
+      "     ### Transform @ConvertPILImage ###    \n",
+      "     ### Transform @ConvertBoxes ###    \n",
+      "     ### Mosaic with Prob.@0.5 and ZoomOut/IoUCrop existed ### \n",
+      "     ### ImgTransforms Epochs: [4, 64, 120] ### \n",
+      "     ### Policy_ops@['Mosaic', 'RandomPhotometricDistort', 'RandomZoomOut', 'RandomIoUCrop'] ###\n",
+      "     ### Using MixUp with Prob@0.5 in [4, 64] epochs ### \n",
+      "     ### Multi-scale Training until 120 epochs ### \n",
+      "     ### Multi-scales@ [480, 512, 544, 576, 608, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 800, 768, 736, 704, 672] ###        \n",
+      "building val_dataloader with batch_size=16...\n",
+      "     ### Transform @Resize ###    \n",
+      "     ### Transform @ConvertPILImage ###    \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 21:01:57.702\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m649\u001b[0m - \u001b[1mLoaded parameters with matching shapes\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.739\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_checkpoint\u001b[0m:\u001b[36m671\u001b[0m - \u001b[1mLoaded checkpoint from epoch 9\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.743\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m239\u001b[0m - \u001b[1mStarting training...\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.743\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m242\u001b[0m - \u001b[1mOverriding epochs to 30\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.743\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m276\u001b[0m - \u001b[1mSetting pretrained flag to True for HGNetv2\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.744\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m296\u001b[0m - \u001b[1mAutomatically calculated mixup epochs: [1, 15]\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.744\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m306\u001b[0m - \u001b[1mAutomatically calculated data augmentation epochs: 1, 15, 27\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.744\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m315\u001b[0m - \u001b[1mAutomatically calculated stop epoch: 27\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.744\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m323\u001b[0m - \u001b[1mAutomatically calculated no augmentation epochs: 3\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.745\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m336\u001b[0m - \u001b[1mAutomatically calculated flat epochs: 15\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.748\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m363\u001b[0m - \u001b[1mAutomatically calculated warmup iterations: 605 (1.5 epochs)\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.749\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m376\u001b[0m - \u001b[1mAutomatically calculated EMA warmups: 605 (1.5 epochs)\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.749\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m152\u001b[0m - \u001b[1mDisabling sync_bn and find_unused_parameters for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.750\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m164\u001b[0m - \u001b[1mSet device in config: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.750\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m174\u001b[0m - \u001b[1mInitializing solver for task: detection\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.785\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m201\u001b[0m - \u001b[1mTraining setup complete. Output directory: outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.786\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m203\u001b[0m - \u001b[1mSaving config to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing/config.yml\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:57.794\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m384\u001b[0m - \u001b[1mUsing device: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:58.114\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:58.116\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m393\u001b[0m - \u001b[1mInitial model saved as best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:58.119\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m403\u001b[0m - \u001b[1mNumber of trainable parameters: 10217817\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:58.119\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m409\u001b[0m - \u001b[1mUsing custom scheduler: flatcosine\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:01:58.119\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 0/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.0002, 0.0004, 0.0004] [0.0001, 0.0002, 0.0002] 12090 605 6045 1209\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 403/403 [01:56<00:00,  3.45it/s, loss=17.1592]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000088  loss: 19.4117 (24.3900)  loss_mal: 0.6772 (1.0626)  loss_bbox: 0.2405 (0.3639)  loss_giou: 0.2484 (0.3325)  loss_fgl: 1.0165 (1.0863)  loss_mal_aux_0: 0.8638 (1.2681)  loss_bbox_aux_0: 0.2830 (0.4363)  loss_giou_aux_0: 0.2865 (0.3983)  loss_fgl_aux_0: 1.1088 (1.1692)  loss_ddf_aux_0: 0.0908 (0.1043)  loss_mal_aux_1: 0.7036 (1.1360)  loss_bbox_aux_1: 0.2601 (0.3721)  loss_giou_aux_1: 0.2459 (0.3398)  loss_fgl_aux_1: 1.0167 (1.0943)  loss_ddf_aux_1: 0.0062 (0.0066)  loss_mal_pre: 0.8599 (1.2658)  loss_bbox_pre: 0.2772 (0.4368)  loss_giou_pre: 0.2818 (0.3981)  loss_mal_enc_0: 1.1650 (1.7527)  loss_bbox_enc_0: 0.4331 (0.7851)  loss_giou_enc_0: 0.3969 (0.6513)  loss_mal_dn_0: 0.6680 (0.7325)  loss_bbox_dn_0: 0.3921 (0.5426)  loss_giou_dn_0: 0.3716 (0.4963)  loss_fgl_dn_0: 1.2100 (1.2478)  loss_ddf_dn_0: 0.2250 (0.2516)  loss_mal_dn_1: 0.5215 (0.6138)  loss_bbox_dn_1: 0.2814 (0.3962)  loss_giou_dn_1: 0.2554 (0.3513)  loss_fgl_dn_1: 1.0249 (1.1073)  loss_ddf_dn_1: 0.0143 (0.0178)  loss_mal_dn_2: 0.5054 (0.5944)  loss_bbox_dn_2: 0.2540 (0.3746)  loss_giou_dn_2: 0.2448 (0.3320)  loss_fgl_dn_2: 1.0178 (1.0930)  loss_mal_dn_pre: 0.6699 (0.7307)  loss_bbox_dn_pre: 0.4011 (0.5520)  loss_giou_dn_pre: 0.3765 (0.4960)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.54it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.680\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.897\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.809\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.309\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.390\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.712\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.698\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.819\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.856\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.666\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.882\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.986\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.963\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 21:04:00.100\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:04:00.102\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 0 / mAP: 0.6798089462087499\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:04:00.102\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 0, 'coco_eval_bbox': 0.6798089462087499}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:04:00.103\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 1/30\u001b[0m\n",
+      "Epoch 1: 100%|██████████| 403/403 [01:52<00:00,  3.58it/s, loss=16.7986]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 19.0964 (19.9460)  loss_mal: 0.7119 (0.7438)  loss_bbox: 0.2425 (0.2663)  loss_giou: 0.2257 (0.2603)  loss_fgl: 1.0231 (1.0613)  loss_mal_aux_0: 0.8218 (0.9122)  loss_bbox_aux_0: 0.2701 (0.3185)  loss_giou_aux_0: 0.2917 (0.3090)  loss_fgl_aux_0: 1.1437 (1.1533)  loss_ddf_aux_0: 0.1002 (0.1035)  loss_mal_aux_1: 0.6982 (0.7807)  loss_bbox_aux_1: 0.2364 (0.2698)  loss_giou_aux_1: 0.2298 (0.2636)  loss_fgl_aux_1: 1.0328 (1.0665)  loss_ddf_aux_1: 0.0053 (0.0067)  loss_mal_pre: 0.8198 (0.9133)  loss_bbox_pre: 0.2750 (0.3166)  loss_giou_pre: 0.2906 (0.3072)  loss_mal_enc_0: 0.9219 (1.1057)  loss_bbox_enc_0: 0.5084 (0.5127)  loss_giou_enc_0: 0.4887 (0.4624)  loss_mal_dn_0: 0.6802 (0.6847)  loss_bbox_dn_0: 0.4299 (0.4165)  loss_giou_dn_0: 0.3998 (0.4019)  loss_fgl_dn_0: 1.2197 (1.2256)  loss_ddf_dn_0: 0.2925 (0.2692)  loss_mal_dn_1: 0.5312 (0.5465)  loss_bbox_dn_1: 0.2642 (0.2832)  loss_giou_dn_1: 0.2579 (0.2736)  loss_fgl_dn_1: 1.0604 (1.0674)  loss_ddf_dn_1: 0.0180 (0.0173)  loss_mal_dn_2: 0.5049 (0.5324)  loss_bbox_dn_2: 0.2344 (0.2695)  loss_giou_dn_2: 0.2450 (0.2624)  loss_fgl_dn_2: 1.0509 (1.0537)  loss_mal_dn_pre: 0.6777 (0.6834)  loss_bbox_dn_pre: 0.4417 (0.4233)  loss_giou_dn_pre: 0.3987 (0.4019)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.63it/s]\n",
+      "\u001b[32m2025-04-03 21:05:57.377\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 0, 'coco_eval_bbox': 0.6798089462087499}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:05:57.378\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 2/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.653\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.860\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.755\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.298\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.462\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.681\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.712\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.823\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.864\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.338\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.698\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.889\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.986\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.965\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 2: 100%|██████████| 403/403 [01:53<00:00,  3.56it/s, loss=17.3891]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 17.3891 (18.5843)  loss_mal: 0.5771 (0.6440)  loss_bbox: 0.1931 (0.2315)  loss_giou: 0.2077 (0.2319)  loss_fgl: 0.9996 (1.0271)  loss_mal_aux_0: 0.8125 (0.8174)  loss_bbox_aux_0: 0.2317 (0.2855)  loss_giou_aux_0: 0.2815 (0.2843)  loss_fgl_aux_0: 1.0868 (1.1348)  loss_ddf_aux_0: 0.1145 (0.1257)  loss_mal_aux_1: 0.5854 (0.6763)  loss_bbox_aux_1: 0.1987 (0.2356)  loss_giou_aux_1: 0.2110 (0.2355)  loss_fgl_aux_1: 0.9985 (1.0324)  loss_ddf_aux_1: 0.0059 (0.0079)  loss_mal_pre: 0.8101 (0.8155)  loss_bbox_pre: 0.2409 (0.2823)  loss_giou_pre: 0.2783 (0.2814)  loss_mal_enc_0: 0.9028 (0.9669)  loss_bbox_enc_0: 0.4617 (0.4543)  loss_giou_enc_0: 0.3874 (0.4214)  loss_mal_dn_0: 0.6440 (0.6576)  loss_bbox_dn_0: 0.3518 (0.3762)  loss_giou_dn_0: 0.3601 (0.3723)  loss_fgl_dn_0: 1.1981 (1.2186)  loss_ddf_dn_0: 0.2885 (0.3184)  loss_mal_dn_1: 0.4863 (0.5075)  loss_bbox_dn_1: 0.2131 (0.2451)  loss_giou_dn_1: 0.2277 (0.2445)  loss_fgl_dn_1: 1.0092 (1.0376)  loss_ddf_dn_1: 0.0151 (0.0210)  loss_mal_dn_2: 0.4636 (0.4926)  loss_bbox_dn_2: 0.2014 (0.2333)  loss_giou_dn_2: 0.2077 (0.2343)  loss_fgl_dn_2: 0.9792 (1.0241)  loss_mal_dn_pre: 0.6416 (0.6562)  loss_bbox_dn_pre: 0.3544 (0.3815)  loss_giou_dn_pre: 0.3604 (0.3717)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.58it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.691\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.877\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.820\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.334\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.523\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.718\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.736\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.843\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.875\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.400\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.762\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.895\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.973\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 21:07:55.769\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:07:55.771\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 2 / mAP: 0.691391135911459\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:07:55.772\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 2, 'coco_eval_bbox': 0.691391135911459}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:07:55.772\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 3/30\u001b[0m\n",
+      "Epoch 3: 100%|██████████| 403/403 [01:53<00:00,  3.54it/s, loss=15.9501]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 16.6024 (17.4524)  loss_mal: 0.4771 (0.5614)  loss_bbox: 0.1940 (0.2038)  loss_giou: 0.1937 (0.2099)  loss_fgl: 0.9501 (0.9986)  loss_mal_aux_0: 0.6143 (0.7272)  loss_bbox_aux_0: 0.2331 (0.2581)  loss_giou_aux_0: 0.2447 (0.2598)  loss_fgl_aux_0: 1.0667 (1.1120)  loss_ddf_aux_0: 0.1020 (0.1324)  loss_mal_aux_1: 0.5474 (0.5936)  loss_bbox_aux_1: 0.1979 (0.2071)  loss_giou_aux_1: 0.1989 (0.2126)  loss_fgl_aux_1: 0.9624 (1.0052)  loss_ddf_aux_1: 0.0058 (0.0073)  loss_mal_pre: 0.6094 (0.7254)  loss_bbox_pre: 0.2260 (0.2562)  loss_giou_pre: 0.2385 (0.2575)  loss_mal_enc_0: 0.8101 (0.8968)  loss_bbox_enc_0: 0.3553 (0.4576)  loss_giou_enc_0: 0.3555 (0.4180)  loss_mal_dn_0: 0.6201 (0.6333)  loss_bbox_dn_0: 0.3183 (0.3371)  loss_giou_dn_0: 0.3339 (0.3411)  loss_fgl_dn_0: 1.1815 (1.2030)  loss_ddf_dn_0: 0.3056 (0.3314)  loss_mal_dn_1: 0.4683 (0.4752)  loss_bbox_dn_1: 0.2069 (0.2113)  loss_giou_dn_1: 0.2044 (0.2183)  loss_fgl_dn_1: 0.9730 (1.0061)  loss_ddf_dn_1: 0.0178 (0.0194)  loss_mal_dn_2: 0.4324 (0.4575)  loss_bbox_dn_2: 0.1940 (0.2010)  loss_giou_dn_2: 0.1981 (0.2097)  loss_fgl_dn_2: 0.9572 (0.9916)  loss_mal_dn_pre: 0.6182 (0.6318)  loss_bbox_dn_pre: 0.3171 (0.3429)  loss_giou_dn_pre: 0.3323 (0.3410)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.61it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.726\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.918\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.847\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.320\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.536\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.753\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.741\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.850\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.880\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.412\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.680\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.903\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.982\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.973\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 21:09:54.745\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:09:54.747\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 3 / mAP: 0.7259081464387614\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:09:54.748\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 3, 'coco_eval_bbox': 0.7259081464387614}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:09:54.748\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 4/30\u001b[0m\n",
+      "Epoch 4: 100%|██████████| 403/403 [02:25<00:00,  2.78it/s, loss=19.3678]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 20.2978 (22.2310)  loss_mal: 0.8252 (0.9117)  loss_bbox: 0.2634 (0.3225)  loss_giou: 0.3821 (0.4551)  loss_fgl: 1.0853 (1.1024)  loss_mal_aux_0: 0.9697 (0.9881)  loss_bbox_aux_0: 0.2536 (0.3419)  loss_giou_aux_0: 0.4120 (0.4907)  loss_fgl_aux_0: 1.1306 (1.1486)  loss_ddf_aux_0: 0.1087 (0.0983)  loss_mal_aux_1: 0.8892 (0.9266)  loss_bbox_aux_1: 0.2539 (0.3237)  loss_giou_aux_1: 0.3816 (0.4570)  loss_fgl_aux_1: 1.0915 (1.1038)  loss_ddf_aux_1: 0.0057 (0.0048)  loss_mal_pre: 0.9492 (0.9880)  loss_bbox_pre: 0.2593 (0.3412)  loss_giou_pre: 0.4101 (0.4899)  loss_mal_enc_0: 1.0078 (1.0455)  loss_bbox_enc_0: 0.3553 (0.4392)  loss_giou_enc_0: 0.5174 (0.6276)  loss_mal_dn_0: 0.6914 (0.7252)  loss_bbox_dn_0: 0.3359 (0.3552)  loss_giou_dn_0: 0.4855 (0.5336)  loss_fgl_dn_0: 1.1948 (1.1998)  loss_ddf_dn_0: 0.2889 (0.2724)  loss_mal_dn_1: 0.5991 (0.6425)  loss_bbox_dn_1: 0.2358 (0.2993)  loss_giou_dn_1: 0.3924 (0.4201)  loss_fgl_dn_1: 1.0839 (1.1045)  loss_ddf_dn_1: 0.0153 (0.0132)  loss_mal_dn_2: 0.5908 (0.6348)  loss_bbox_dn_2: 0.2314 (0.2956)  loss_giou_dn_2: 0.3856 (0.4129)  loss_fgl_dn_2: 1.0809 (1.1007)  loss_mal_dn_pre: 0.6919 (0.7252)  loss_bbox_dn_pre: 0.3338 (0.3557)  loss_giou_dn_pre: 0.4848 (0.5338)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.26it/s]\n",
+      "\u001b[32m2025-04-03 21:12:24.984\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 3, 'coco_eval_bbox': 0.7259081464387614}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:12:24.984\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 5/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.08s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.692\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.893\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.816\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.363\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.450\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.722\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.724\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.816\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.859\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.388\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.667\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.884\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.966\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 5: 100%|██████████| 403/403 [02:44<00:00,  2.46it/s, loss=23.1062]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 18.8316 (21.0811)  loss_mal: 0.6812 (0.8446)  loss_bbox: 0.1924 (0.2854)  loss_giou: 0.3190 (0.4123)  loss_fgl: 1.0881 (1.0935)  loss_mal_aux_0: 0.8096 (0.9187)  loss_bbox_aux_0: 0.2293 (0.3045)  loss_giou_aux_0: 0.3414 (0.4459)  loss_fgl_aux_0: 1.1478 (1.1453)  loss_ddf_aux_0: 0.0782 (0.0997)  loss_mal_aux_1: 0.6938 (0.8631)  loss_bbox_aux_1: 0.1994 (0.2868)  loss_giou_aux_1: 0.3155 (0.4140)  loss_fgl_aux_1: 1.0902 (1.0955)  loss_ddf_aux_1: 0.0045 (0.0047)  loss_mal_pre: 0.8081 (0.9175)  loss_bbox_pre: 0.2267 (0.3034)  loss_giou_pre: 0.3420 (0.4445)  loss_mal_enc_0: 0.9688 (1.0007)  loss_bbox_enc_0: 0.3923 (0.3976)  loss_giou_enc_0: 0.5582 (0.5740)  loss_mal_dn_0: 0.6777 (0.7064)  loss_bbox_dn_0: 0.2606 (0.3261)  loss_giou_dn_0: 0.4089 (0.4943)  loss_fgl_dn_0: 1.2006 (1.1978)  loss_ddf_dn_0: 0.2393 (0.2668)  loss_mal_dn_1: 0.5610 (0.6144)  loss_bbox_dn_1: 0.1970 (0.2703)  loss_giou_dn_1: 0.2913 (0.3856)  loss_fgl_dn_1: 1.0958 (1.0903)  loss_ddf_dn_1: 0.0132 (0.0117)  loss_mal_dn_2: 0.5625 (0.6066)  loss_bbox_dn_2: 0.1962 (0.2667)  loss_giou_dn_2: 0.2901 (0.3792)  loss_fgl_dn_2: 1.0954 (1.0858)  loss_mal_dn_pre: 0.6782 (0.7060)  loss_bbox_dn_pre: 0.2656 (0.3273)  loss_giou_dn_pre: 0.4119 (0.4942)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.99it/s]\n",
+      "\u001b[32m2025-04-03 21:15:14.245\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 3, 'coco_eval_bbox': 0.7259081464387614}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:15:14.245\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 6/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.715\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.917\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.838\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.376\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.483\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.742\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.734\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.820\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.854\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.400\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.705\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.876\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.961\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 6: 100%|██████████| 403/403 [02:31<00:00,  2.67it/s, loss=19.1424]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 21.9460 (20.7154)  loss_mal: 0.8564 (0.8238)  loss_bbox: 0.2540 (0.2755)  loss_giou: 0.4078 (0.3985)  loss_fgl: 1.0752 (1.0866)  loss_mal_aux_0: 0.8892 (0.9039)  loss_bbox_aux_0: 0.2655 (0.2948)  loss_giou_aux_0: 0.4377 (0.4322)  loss_fgl_aux_0: 1.1321 (1.1409)  loss_ddf_aux_0: 0.1046 (0.1020)  loss_mal_aux_1: 0.8726 (0.8372)  loss_bbox_aux_1: 0.2540 (0.2769)  loss_giou_aux_1: 0.4057 (0.4002)  loss_fgl_aux_1: 1.0798 (1.0886)  loss_ddf_aux_1: 0.0042 (0.0046)  loss_mal_pre: 0.8955 (0.9031)  loss_bbox_pre: 0.2654 (0.2940)  loss_giou_pre: 0.4352 (0.4310)  loss_mal_enc_0: 0.9897 (0.9886)  loss_bbox_enc_0: 0.3811 (0.3888)  loss_giou_enc_0: 0.5357 (0.5628)  loss_mal_dn_0: 0.7114 (0.6981)  loss_bbox_dn_0: 0.2608 (0.3190)  loss_giou_dn_0: 0.5006 (0.4777)  loss_fgl_dn_0: 1.1892 (1.1928)  loss_ddf_dn_0: 0.2887 (0.2673)  loss_mal_dn_1: 0.6226 (0.6033)  loss_bbox_dn_1: 0.2137 (0.2641)  loss_giou_dn_1: 0.3919 (0.3736)  loss_fgl_dn_1: 1.0684 (1.0801)  loss_ddf_dn_1: 0.0117 (0.0113)  loss_mal_dn_2: 0.6143 (0.5951)  loss_bbox_dn_2: 0.2157 (0.2604)  loss_giou_dn_2: 0.3855 (0.3675)  loss_fgl_dn_2: 1.0640 (1.0755)  loss_mal_dn_pre: 0.7114 (0.6976)  loss_bbox_dn_pre: 0.2631 (0.3203)  loss_giou_dn_pre: 0.5040 (0.4776)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.31it/s]\n",
+      "\u001b[32m2025-04-03 21:17:50.343\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 3, 'coco_eval_bbox': 0.7259081464387614}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:17:50.344\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 7/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.714\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.925\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.834\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.347\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.497\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.741\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.727\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.812\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.837\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.650\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.860\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.938\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 7: 100%|██████████| 403/403 [02:28<00:00,  2.72it/s, loss=22.2579]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 20.2974 (20.3609)  loss_mal: 0.7793 (0.8013)  loss_bbox: 0.2563 (0.2723)  loss_giou: 0.3413 (0.3899)  loss_fgl: 1.0684 (1.0790)  loss_mal_aux_0: 0.8608 (0.8813)  loss_bbox_aux_0: 0.2658 (0.2875)  loss_giou_aux_0: 0.3770 (0.4179)  loss_fgl_aux_0: 1.1174 (1.1320)  loss_ddf_aux_0: 0.0964 (0.0964)  loss_mal_aux_1: 0.7637 (0.8161)  loss_bbox_aux_1: 0.2603 (0.2731)  loss_giou_aux_1: 0.3386 (0.3914)  loss_fgl_aux_1: 1.0714 (1.0805)  loss_ddf_aux_1: 0.0057 (0.0043)  loss_mal_pre: 0.8652 (0.8800)  loss_bbox_pre: 0.2627 (0.2867)  loss_giou_pre: 0.3748 (0.4165)  loss_mal_enc_0: 0.9302 (0.9725)  loss_bbox_enc_0: 0.4163 (0.3727)  loss_giou_enc_0: 0.5384 (0.5363)  loss_mal_dn_0: 0.6924 (0.6915)  loss_bbox_dn_0: 0.2967 (0.3135)  loss_giou_dn_0: 0.4098 (0.4659)  loss_fgl_dn_0: 1.1892 (1.1892)  loss_ddf_dn_0: 0.2791 (0.2632)  loss_mal_dn_1: 0.5918 (0.5950)  loss_bbox_dn_1: 0.2446 (0.2597)  loss_giou_dn_1: 0.3051 (0.3657)  loss_fgl_dn_1: 1.0717 (1.0747)  loss_ddf_dn_1: 0.0139 (0.0108)  loss_mal_dn_2: 0.5767 (0.5865)  loss_bbox_dn_2: 0.2422 (0.2561)  loss_giou_dn_2: 0.2986 (0.3600)  loss_fgl_dn_2: 1.0633 (1.0704)  loss_mal_dn_pre: 0.6924 (0.6909)  loss_bbox_dn_pre: 0.2977 (0.3146)  loss_giou_dn_pre: 0.4106 (0.4654)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.67it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.726\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.930\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.858\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.317\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.518\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.754\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.737\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.807\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.838\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.667\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.862\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.943\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 21:20:23.548\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:20:23.550\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 7 / mAP: 0.7260832526743252\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:20:23.551\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 7, 'coco_eval_bbox': 0.7260832526743252}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:20:23.551\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 8/30\u001b[0m\n",
+      "Epoch 8: 100%|██████████| 403/403 [02:32<00:00,  2.64it/s, loss=17.1242]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 21.6777 (20.4901)  loss_mal: 0.8745 (0.8108)  loss_bbox: 0.3251 (0.2733)  loss_giou: 0.4515 (0.3991)  loss_fgl: 1.1010 (1.0796)  loss_mal_aux_0: 0.9541 (0.8844)  loss_bbox_aux_0: 0.3321 (0.2897)  loss_giou_aux_0: 0.4776 (0.4298)  loss_fgl_aux_0: 1.1496 (1.1326)  loss_ddf_aux_0: 0.0865 (0.0959)  loss_mal_aux_1: 0.8887 (0.8260)  loss_bbox_aux_1: 0.3247 (0.2742)  loss_giou_aux_1: 0.4522 (0.4007)  loss_fgl_aux_1: 1.1008 (1.0812)  loss_ddf_aux_1: 0.0039 (0.0040)  loss_mal_pre: 0.9629 (0.8836)  loss_bbox_pre: 0.3324 (0.2892)  loss_giou_pre: 0.4756 (0.4285)  loss_mal_enc_0: 1.0000 (0.9726)  loss_bbox_enc_0: 0.4584 (0.3801)  loss_giou_enc_0: 0.6104 (0.5591)  loss_mal_dn_0: 0.7319 (0.6940)  loss_bbox_dn_0: 0.3036 (0.3136)  loss_giou_dn_0: 0.5309 (0.4716)  loss_fgl_dn_0: 1.1770 (1.1889)  loss_ddf_dn_0: 0.2386 (0.2561)  loss_mal_dn_1: 0.6445 (0.5963)  loss_bbox_dn_1: 0.2567 (0.2588)  loss_giou_dn_1: 0.4305 (0.3706)  loss_fgl_dn_1: 1.0822 (1.0764)  loss_ddf_dn_1: 0.0091 (0.0099)  loss_mal_dn_2: 0.6387 (0.5876)  loss_bbox_dn_2: 0.2582 (0.2553)  loss_giou_dn_2: 0.4164 (0.3648)  loss_fgl_dn_2: 1.0809 (1.0720)  loss_mal_dn_pre: 0.7319 (0.6935)  loss_bbox_dn_pre: 0.3098 (0.3150)  loss_giou_dn_pre: 0.5310 (0.4712)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.37it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.732\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.921\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.851\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.314\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.542\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.759\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.740\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.815\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.852\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.674\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.876\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.954\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 21:23:01.237\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:23:01.238\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 8 / mAP: 0.7323541495261611\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:23:01.239\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 8, 'coco_eval_bbox': 0.7323541495261611}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:23:01.239\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 9/30\u001b[0m\n",
+      "Epoch 9: 100%|██████████| 403/403 [02:33<00:00,  2.63it/s, loss=24.2352]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 17.5129 (19.8934)  loss_mal: 0.6226 (0.7701)  loss_bbox: 0.1912 (0.2600)  loss_giou: 0.3206 (0.3829)  loss_fgl: 1.0420 (1.0718)  loss_mal_aux_0: 0.7148 (0.8410)  loss_bbox_aux_0: 0.2442 (0.2766)  loss_giou_aux_0: 0.3919 (0.4143)  loss_fgl_aux_0: 1.1105 (1.1273)  loss_ddf_aux_0: 0.0927 (0.0952)  loss_mal_aux_1: 0.6431 (0.7831)  loss_bbox_aux_1: 0.1911 (0.2610)  loss_giou_aux_1: 0.3255 (0.3846)  loss_fgl_aux_1: 1.0444 (1.0739)  loss_ddf_aux_1: 0.0051 (0.0043)  loss_mal_pre: 0.7178 (0.8404)  loss_bbox_pre: 0.2402 (0.2758)  loss_giou_pre: 0.3940 (0.4129)  loss_mal_enc_0: 0.8496 (0.9453)  loss_bbox_enc_0: 0.3304 (0.3641)  loss_giou_enc_0: 0.5038 (0.5388)  loss_mal_dn_0: 0.6396 (0.6813)  loss_bbox_dn_0: 0.2285 (0.2980)  loss_giou_dn_0: 0.3740 (0.4492)  loss_fgl_dn_0: 1.1789 (1.1845)  loss_ddf_dn_0: 0.2732 (0.2475)  loss_mal_dn_1: 0.5171 (0.5804)  loss_bbox_dn_1: 0.1727 (0.2447)  loss_giou_dn_1: 0.2718 (0.3524)  loss_fgl_dn_1: 1.0588 (1.0686)  loss_ddf_dn_1: 0.0095 (0.0098)  loss_mal_dn_2: 0.5107 (0.5721)  loss_bbox_dn_2: 0.1660 (0.2414)  loss_giou_dn_2: 0.2722 (0.3471)  loss_fgl_dn_2: 1.0532 (1.0646)  loss_mal_dn_pre: 0.6406 (0.6807)  loss_bbox_dn_pre: 0.2287 (0.2993)  loss_giou_dn_pre: 0.3762 (0.4486)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.09it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.748\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.935\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.870\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.338\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.534\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.773\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.746\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.824\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.859\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.400\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.706\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.879\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.951\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 21:25:39.750\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:25:39.751\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 9 / mAP: 0.7475741830997051\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:25:39.753\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 9, 'coco_eval_bbox': 0.7475741830997051}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:25:39.753\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 10/30\u001b[0m\n",
+      "Epoch 10: 100%|██████████| 403/403 [02:46<00:00,  2.42it/s, loss=23.4202]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 21.2283 (19.9574)  loss_mal: 0.7847 (0.7787)  loss_bbox: 0.3108 (0.2647)  loss_giou: 0.4071 (0.3812)  loss_fgl: 1.0865 (1.0708)  loss_mal_aux_0: 0.8721 (0.8529)  loss_bbox_aux_0: 0.3235 (0.2823)  loss_giou_aux_0: 0.4252 (0.4126)  loss_fgl_aux_0: 1.1323 (1.1259)  loss_ddf_aux_0: 0.0945 (0.0985)  loss_mal_aux_1: 0.8262 (0.7969)  loss_bbox_aux_1: 0.3145 (0.2654)  loss_giou_aux_1: 0.4080 (0.3827)  loss_fgl_aux_1: 1.0867 (1.0727)  loss_ddf_aux_1: 0.0046 (0.0044)  loss_mal_pre: 0.8643 (0.8521)  loss_bbox_pre: 0.3231 (0.2816)  loss_giou_pre: 0.4187 (0.4112)  loss_mal_enc_0: 0.9507 (0.9381)  loss_bbox_enc_0: 0.3810 (0.3744)  loss_giou_enc_0: 0.5506 (0.5364)  loss_mal_dn_0: 0.6948 (0.6810)  loss_bbox_dn_0: 0.3442 (0.3004)  loss_giou_dn_0: 0.4954 (0.4474)  loss_fgl_dn_0: 1.1825 (1.1825)  loss_ddf_dn_0: 0.2327 (0.2524)  loss_mal_dn_1: 0.6279 (0.5802)  loss_bbox_dn_1: 0.2883 (0.2469)  loss_giou_dn_1: 0.4076 (0.3519)  loss_fgl_dn_1: 1.0920 (1.0672)  loss_ddf_dn_1: 0.0108 (0.0105)  loss_mal_dn_2: 0.6187 (0.5723)  loss_bbox_dn_2: 0.2844 (0.2432)  loss_giou_dn_2: 0.3965 (0.3463)  loss_fgl_dn_2: 1.0865 (1.0629)  loss_mal_dn_pre: 0.6958 (0.6805)  loss_bbox_dn_pre: 0.3398 (0.3014)  loss_giou_dn_pre: 0.4996 (0.4465)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.06it/s]\n",
+      "\u001b[32m2025-04-03 21:28:31.416\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 9, 'coco_eval_bbox': 0.7475741830997051}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:28:31.417\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 11/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.737\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.926\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.847\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.339\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.535\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.763\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.744\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.830\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.865\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.685\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.889\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.966\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 11: 100%|██████████| 403/403 [02:42<00:00,  2.48it/s, loss=20.7901]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 20.7901 (19.7131)  loss_mal: 0.7749 (0.7595)  loss_bbox: 0.2926 (0.2601)  loss_giou: 0.3893 (0.3807)  loss_fgl: 1.0507 (1.0655)  loss_mal_aux_0: 0.7627 (0.8264)  loss_bbox_aux_0: 0.2995 (0.2778)  loss_giou_aux_0: 0.4171 (0.4119)  loss_fgl_aux_0: 1.1098 (1.1213)  loss_ddf_aux_0: 0.0929 (0.0970)  loss_mal_aux_1: 0.7485 (0.7726)  loss_bbox_aux_1: 0.2936 (0.2612)  loss_giou_aux_1: 0.3923 (0.3824)  loss_fgl_aux_1: 1.0521 (1.0674)  loss_ddf_aux_1: 0.0044 (0.0044)  loss_mal_pre: 0.7593 (0.8255)  loss_bbox_pre: 0.3014 (0.2770)  loss_giou_pre: 0.4216 (0.4105)  loss_mal_enc_0: 0.8857 (0.9276)  loss_bbox_enc_0: 0.3917 (0.3650)  loss_giou_enc_0: 0.5637 (0.5315)  loss_mal_dn_0: 0.6978 (0.6750)  loss_bbox_dn_0: 0.2905 (0.2917)  loss_giou_dn_0: 0.4589 (0.4421)  loss_fgl_dn_0: 1.1724 (1.1798)  loss_ddf_dn_0: 0.2246 (0.2453)  loss_mal_dn_1: 0.6040 (0.5751)  loss_bbox_dn_1: 0.2393 (0.2406)  loss_giou_dn_1: 0.3701 (0.3495)  loss_fgl_dn_1: 1.0831 (1.0632)  loss_ddf_dn_1: 0.0090 (0.0097)  loss_mal_dn_2: 0.6030 (0.5669)  loss_bbox_dn_2: 0.2371 (0.2371)  loss_giou_dn_2: 0.3660 (0.3444)  loss_fgl_dn_2: 1.0753 (1.0591)  loss_mal_dn_pre: 0.6973 (0.6744)  loss_bbox_dn_pre: 0.2948 (0.2929)  loss_giou_dn_pre: 0.4595 (0.4413)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.87it/s]\n",
+      "\u001b[32m2025-04-03 21:31:19.108\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 9, 'coco_eval_bbox': 0.7475741830997051}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:31:19.108\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 12/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.743\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.928\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.857\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.351\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.550\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.769\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.746\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.836\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.871\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.720\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.892\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.968\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 12: 100%|██████████| 403/403 [02:41<00:00,  2.49it/s, loss=22.2182]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 20.4810 (19.5051)  loss_mal: 0.7764 (0.7492)  loss_bbox: 0.3034 (0.2511)  loss_giou: 0.4024 (0.3757)  loss_fgl: 1.0823 (1.0609)  loss_mal_aux_0: 0.8008 (0.8168)  loss_bbox_aux_0: 0.3222 (0.2667)  loss_giou_aux_0: 0.4142 (0.4052)  loss_fgl_aux_0: 1.1308 (1.1142)  loss_ddf_aux_0: 0.0823 (0.0939)  loss_mal_aux_1: 0.7725 (0.7636)  loss_bbox_aux_1: 0.2972 (0.2520)  loss_giou_aux_1: 0.4005 (0.3774)  loss_fgl_aux_1: 1.0769 (1.0628)  loss_ddf_aux_1: 0.0037 (0.0042)  loss_mal_pre: 0.7974 (0.8159)  loss_bbox_pre: 0.3207 (0.2658)  loss_giou_pre: 0.4102 (0.4036)  loss_mal_enc_0: 0.8584 (0.9239)  loss_bbox_enc_0: 0.4310 (0.3546)  loss_giou_enc_0: 0.5432 (0.5348)  loss_mal_dn_0: 0.6758 (0.6719)  loss_bbox_dn_0: 0.3165 (0.2871)  loss_giou_dn_0: 0.4197 (0.4352)  loss_fgl_dn_0: 1.1684 (1.1763)  loss_ddf_dn_0: 0.2249 (0.2484)  loss_mal_dn_1: 0.5664 (0.5710)  loss_bbox_dn_1: 0.2950 (0.2356)  loss_giou_dn_1: 0.3561 (0.3424)  loss_fgl_dn_1: 1.0626 (1.0569)  loss_ddf_dn_1: 0.0084 (0.0096)  loss_mal_dn_2: 0.5557 (0.5621)  loss_bbox_dn_2: 0.2957 (0.2323)  loss_giou_dn_2: 0.3553 (0.3372)  loss_fgl_dn_2: 1.0616 (1.0525)  loss_mal_dn_pre: 0.6738 (0.6712)  loss_bbox_dn_pre: 0.3304 (0.2886)  loss_giou_dn_pre: 0.4178 (0.4346)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.14it/s]\n",
+      "\u001b[32m2025-04-03 21:34:06.108\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 9, 'coco_eval_bbox': 0.7475741830997051}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:34:06.109\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 13/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.745\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.928\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.866\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.326\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.512\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.772\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.748\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.833\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.865\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.700\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.885\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.973\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 13: 100%|██████████| 403/403 [02:44<00:00,  2.46it/s, loss=21.5508]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 17.5323 (19.6634)  loss_mal: 0.6670 (0.7606)  loss_bbox: 0.2543 (0.2608)  loss_giou: 0.2418 (0.3758)  loss_fgl: 1.0425 (1.0617)  loss_mal_aux_0: 0.7637 (0.8311)  loss_bbox_aux_0: 0.2865 (0.2775)  loss_giou_aux_0: 0.3080 (0.4053)  loss_fgl_aux_0: 1.0939 (1.1181)  loss_ddf_aux_0: 0.1041 (0.0966)  loss_mal_aux_1: 0.6592 (0.7758)  loss_bbox_aux_1: 0.2368 (0.2619)  loss_giou_aux_1: 0.2425 (0.3773)  loss_fgl_aux_1: 1.0422 (1.0635)  loss_ddf_aux_1: 0.0042 (0.0042)  loss_mal_pre: 0.7480 (0.8302)  loss_bbox_pre: 0.2819 (0.2769)  loss_giou_pre: 0.3007 (0.4041)  loss_mal_enc_0: 0.8726 (0.9314)  loss_bbox_enc_0: 0.3876 (0.3757)  loss_giou_enc_0: 0.4783 (0.5388)  loss_mal_dn_0: 0.6567 (0.6719)  loss_bbox_dn_0: 0.2829 (0.2938)  loss_giou_dn_0: 0.3664 (0.4359)  loss_fgl_dn_0: 1.1751 (1.1750)  loss_ddf_dn_0: 0.2308 (0.2451)  loss_mal_dn_1: 0.5122 (0.5695)  loss_bbox_dn_1: 0.2490 (0.2420)  loss_giou_dn_1: 0.2446 (0.3440)  loss_fgl_dn_1: 1.0578 (1.0565)  loss_ddf_dn_1: 0.0085 (0.0093)  loss_mal_dn_2: 0.5156 (0.5615)  loss_bbox_dn_2: 0.2490 (0.2387)  loss_giou_dn_2: 0.2398 (0.3389)  loss_fgl_dn_2: 1.0560 (1.0524)  loss_mal_dn_pre: 0.6528 (0.6713)  loss_bbox_dn_pre: 0.2824 (0.2948)  loss_giou_dn_pre: 0.3619 (0.4353)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.13it/s]\n",
+      "\u001b[32m2025-04-03 21:36:55.420\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 9, 'coco_eval_bbox': 0.7475741830997051}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:36:55.421\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 14/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.08s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.745\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.930\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.853\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.313\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.538\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.771\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.750\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.826\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.859\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.675\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.882\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.957\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 14: 100%|██████████| 403/403 [02:37<00:00,  2.55it/s, loss=20.7375]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 16.9232 (18.9275)  loss_mal: 0.6763 (0.7167)  loss_bbox: 0.1492 (0.2341)  loss_giou: 0.2787 (0.3514)  loss_fgl: 1.0302 (1.0538)  loss_mal_aux_0: 0.7036 (0.7911)  loss_bbox_aux_0: 0.1743 (0.2515)  loss_giou_aux_0: 0.3084 (0.3817)  loss_fgl_aux_0: 1.0909 (1.1125)  loss_ddf_aux_0: 0.0837 (0.1003)  loss_mal_aux_1: 0.6875 (0.7358)  loss_bbox_aux_1: 0.1526 (0.2353)  loss_giou_aux_1: 0.2796 (0.3531)  loss_fgl_aux_1: 1.0330 (1.0558)  loss_ddf_aux_1: 0.0036 (0.0045)  loss_mal_pre: 0.7012 (0.7902)  loss_bbox_pre: 0.1770 (0.2507)  loss_giou_pre: 0.3061 (0.3801)  loss_mal_enc_0: 0.8633 (0.9020)  loss_bbox_enc_0: 0.3189 (0.3445)  loss_giou_enc_0: 0.4827 (0.5096)  loss_mal_dn_0: 0.6299 (0.6583)  loss_bbox_dn_0: 0.2121 (0.2689)  loss_giou_dn_0: 0.3581 (0.4136)  loss_fgl_dn_0: 1.1894 (1.1733)  loss_ddf_dn_0: 0.2285 (0.2506)  loss_mal_dn_1: 0.5156 (0.5511)  loss_bbox_dn_1: 0.1607 (0.2179)  loss_giou_dn_1: 0.2551 (0.3225)  loss_fgl_dn_1: 1.0211 (1.0479)  loss_ddf_dn_1: 0.0090 (0.0095)  loss_mal_dn_2: 0.5059 (0.5432)  loss_bbox_dn_2: 0.1490 (0.2148)  loss_giou_dn_2: 0.2496 (0.3176)  loss_fgl_dn_2: 1.0089 (1.0433)  loss_mal_dn_pre: 0.6294 (0.6575)  loss_bbox_dn_pre: 0.2119 (0.2699)  loss_giou_dn_pre: 0.3547 (0.4127)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.31it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.751\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.931\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.860\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.307\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.543\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.778\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.753\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.829\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.862\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.700\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.884\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.982\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.959\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 21:39:38.605\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:39:38.607\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 14 / mAP: 0.7513420307969209\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:39:38.608\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 14, 'coco_eval_bbox': 0.7513420307969209}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:39:38.608\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 15/30\u001b[0m\n",
+      "Epoch 15: 100%|██████████| 403/403 [02:40<00:00,  2.51it/s, loss=21.6808]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000198  loss: 20.0360 (19.0545)  loss_mal: 0.7422 (0.7207)  loss_bbox: 0.2305 (0.2455)  loss_giou: 0.3337 (0.3650)  loss_fgl: 1.0644 (1.0518)  loss_mal_aux_0: 0.8940 (0.7885)  loss_bbox_aux_0: 0.2575 (0.2614)  loss_giou_aux_0: 0.3601 (0.3924)  loss_fgl_aux_0: 1.1190 (1.1062)  loss_ddf_aux_0: 0.0839 (0.0890)  loss_mal_aux_1: 0.8120 (0.7350)  loss_bbox_aux_1: 0.2313 (0.2465)  loss_giou_aux_1: 0.3327 (0.3666)  loss_fgl_aux_1: 1.0662 (1.0535)  loss_ddf_aux_1: 0.0040 (0.0041)  loss_mal_pre: 0.8677 (0.7883)  loss_bbox_pre: 0.2607 (0.2604)  loss_giou_pre: 0.3580 (0.3908)  loss_mal_enc_0: 0.9121 (0.8934)  loss_bbox_enc_0: 0.3698 (0.3519)  loss_giou_enc_0: 0.5661 (0.5200)  loss_mal_dn_0: 0.6943 (0.6599)  loss_bbox_dn_0: 0.2914 (0.2747)  loss_giou_dn_0: 0.4334 (0.4189)  loss_fgl_dn_0: 1.1868 (1.1695)  loss_ddf_dn_0: 0.2195 (0.2402)  loss_mal_dn_1: 0.6060 (0.5551)  loss_bbox_dn_1: 0.2290 (0.2246)  loss_giou_dn_1: 0.3554 (0.3308)  loss_fgl_dn_1: 1.0650 (1.0479)  loss_ddf_dn_1: 0.0088 (0.0093)  loss_mal_dn_2: 0.5962 (0.5479)  loss_bbox_dn_2: 0.2248 (0.2215)  loss_giou_dn_2: 0.3522 (0.3260)  loss_fgl_dn_2: 1.0636 (1.0439)  loss_mal_dn_pre: 0.6934 (0.6591)  loss_bbox_dn_pre: 0.2881 (0.2759)  loss_giou_dn_pre: 0.4314 (0.4182)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.10it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.756\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.932\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.858\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.307\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.559\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.782\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.756\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.834\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.860\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.692\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.884\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.982\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.948\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 21:42:24.467\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:42:24.469\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 15 / mAP: 0.7564426878028832\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:42:24.469\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 15, 'coco_eval_bbox': 0.7564426878028832}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:42:24.470\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 16/30\u001b[0m\n",
+      "Epoch 16: 100%|██████████| 403/403 [02:30<00:00,  2.67it/s, loss=22.1689]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000193  loss: 17.4362 (18.6813)  loss_mal: 0.6055 (0.6961)  loss_bbox: 0.2045 (0.2380)  loss_giou: 0.2907 (0.3481)  loss_fgl: 1.0429 (1.0441)  loss_mal_aux_0: 0.6670 (0.7689)  loss_bbox_aux_0: 0.2399 (0.2546)  loss_giou_aux_0: 0.3235 (0.3763)  loss_fgl_aux_0: 1.0792 (1.1019)  loss_ddf_aux_0: 0.0946 (0.0941)  loss_mal_aux_1: 0.6465 (0.7139)  loss_bbox_aux_1: 0.2017 (0.2389)  loss_giou_aux_1: 0.2917 (0.3494)  loss_fgl_aux_1: 1.0374 (1.0460)  loss_ddf_aux_1: 0.0043 (0.0043)  loss_mal_pre: 0.6670 (0.7676)  loss_bbox_pre: 0.2292 (0.2542)  loss_giou_pre: 0.3209 (0.3750)  loss_mal_enc_0: 0.8677 (0.8751)  loss_bbox_enc_0: 0.2955 (0.3434)  loss_giou_enc_0: 0.4520 (0.4984)  loss_mal_dn_0: 0.6230 (0.6507)  loss_bbox_dn_0: 0.2099 (0.2700)  loss_giou_dn_0: 0.3517 (0.4067)  loss_fgl_dn_0: 1.1646 (1.1646)  loss_ddf_dn_0: 0.2561 (0.2500)  loss_mal_dn_1: 0.5171 (0.5424)  loss_bbox_dn_1: 0.1655 (0.2195)  loss_giou_dn_1: 0.2846 (0.3185)  loss_fgl_dn_1: 1.0450 (1.0374)  loss_ddf_dn_1: 0.0092 (0.0091)  loss_mal_dn_2: 0.5142 (0.5341)  loss_bbox_dn_2: 0.1610 (0.2164)  loss_giou_dn_2: 0.2800 (0.3139)  loss_fgl_dn_2: 1.0420 (1.0328)  loss_mal_dn_pre: 0.6211 (0.6498)  loss_bbox_dn_pre: 0.2105 (0.2712)  loss_giou_dn_pre: 0.3493 (0.4058)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.42it/s]\n",
+      "\u001b[32m2025-04-03 21:45:00.249\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 15, 'coco_eval_bbox': 0.7564426878028832}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:45:00.250\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 17/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.756\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.933\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.858\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.307\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.560\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.782\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.755\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.841\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.865\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.692\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.889\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.951\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 17: 100%|██████████| 403/403 [02:26<00:00,  2.75it/s, loss=21.8055]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000185  loss: 18.2861 (18.7120)  loss_mal: 0.6323 (0.7151)  loss_bbox: 0.1774 (0.2339)  loss_giou: 0.3066 (0.3483)  loss_fgl: 1.0000 (1.0429)  loss_mal_aux_0: 0.6899 (0.7800)  loss_bbox_aux_0: 0.2129 (0.2505)  loss_giou_aux_0: 0.3484 (0.3763)  loss_fgl_aux_0: 1.0679 (1.1003)  loss_ddf_aux_0: 0.0839 (0.0938)  loss_mal_aux_1: 0.6616 (0.7302)  loss_bbox_aux_1: 0.1912 (0.2349)  loss_giou_aux_1: 0.3080 (0.3498)  loss_fgl_aux_1: 1.0026 (1.0451)  loss_ddf_aux_1: 0.0035 (0.0044)  loss_mal_pre: 0.6978 (0.7791)  loss_bbox_pre: 0.2082 (0.2497)  loss_giou_pre: 0.3524 (0.3751)  loss_mal_enc_0: 0.8569 (0.8865)  loss_bbox_enc_0: 0.2990 (0.3422)  loss_giou_enc_0: 0.4672 (0.5002)  loss_mal_dn_0: 0.6387 (0.6495)  loss_bbox_dn_0: 0.2195 (0.2672)  loss_giou_dn_0: 0.3783 (0.4052)  loss_fgl_dn_0: 1.1427 (1.1601)  loss_ddf_dn_0: 0.2204 (0.2403)  loss_mal_dn_1: 0.5347 (0.5451)  loss_bbox_dn_1: 0.1787 (0.2181)  loss_giou_dn_1: 0.3054 (0.3205)  loss_fgl_dn_1: 1.0373 (1.0367)  loss_ddf_dn_1: 0.0071 (0.0093)  loss_mal_dn_2: 0.5298 (0.5368)  loss_bbox_dn_2: 0.1726 (0.2150)  loss_giou_dn_2: 0.3061 (0.3159)  loss_fgl_dn_2: 1.0327 (1.0324)  loss_mal_dn_pre: 0.6406 (0.6489)  loss_bbox_dn_pre: 0.2270 (0.2683)  loss_giou_dn_pre: 0.3769 (0.4045)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.41it/s]\n",
+      "\u001b[32m2025-04-03 21:47:31.718\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 15, 'coco_eval_bbox': 0.7564426878028832}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:47:31.719\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 18/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.753\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.931\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.865\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.576\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.779\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.754\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.837\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.857\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.338\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.686\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.882\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.946\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 18: 100%|██████████| 403/403 [02:30<00:00,  2.68it/s, loss=19.9531]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000175  loss: 16.3511 (18.7280)  loss_mal: 0.5474 (0.7040)  loss_bbox: 0.1725 (0.2433)  loss_giou: 0.2686 (0.3537)  loss_fgl: 1.0324 (1.0429)  loss_mal_aux_0: 0.6177 (0.7677)  loss_bbox_aux_0: 0.1975 (0.2595)  loss_giou_aux_0: 0.3048 (0.3798)  loss_fgl_aux_0: 1.0775 (1.0961)  loss_ddf_aux_0: 0.0861 (0.0893)  loss_mal_aux_1: 0.5933 (0.7193)  loss_bbox_aux_1: 0.1745 (0.2444)  loss_giou_aux_1: 0.2717 (0.3552)  loss_fgl_aux_1: 1.0359 (1.0450)  loss_ddf_aux_1: 0.0037 (0.0040)  loss_mal_pre: 0.6206 (0.7674)  loss_bbox_pre: 0.1987 (0.2587)  loss_giou_pre: 0.3050 (0.3785)  loss_mal_enc_0: 0.7915 (0.8763)  loss_bbox_enc_0: 0.2600 (0.3441)  loss_giou_enc_0: 0.4267 (0.4963)  loss_mal_dn_0: 0.6138 (0.6497)  loss_bbox_dn_0: 0.2152 (0.2737)  loss_giou_dn_0: 0.3277 (0.4067)  loss_fgl_dn_0: 1.1507 (1.1617)  loss_ddf_dn_0: 0.2418 (0.2424)  loss_mal_dn_1: 0.4932 (0.5436)  loss_bbox_dn_1: 0.1654 (0.2229)  loss_giou_dn_1: 0.2364 (0.3210)  loss_fgl_dn_1: 1.0178 (1.0375)  loss_ddf_dn_1: 0.0077 (0.0090)  loss_mal_dn_2: 0.4805 (0.5354)  loss_bbox_dn_2: 0.1619 (0.2196)  loss_giou_dn_2: 0.2321 (0.3163)  loss_fgl_dn_2: 1.0127 (1.0333)  loss_mal_dn_pre: 0.6118 (0.6490)  loss_bbox_dn_pre: 0.2158 (0.2749)  loss_giou_dn_pre: 0.3273 (0.4059)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.46it/s]\n",
+      "\u001b[32m2025-04-03 21:50:07.274\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 15, 'coco_eval_bbox': 0.7564426878028832}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:50:07.274\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 19/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.751\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.934\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.862\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.568\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.776\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.754\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.833\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.856\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.686\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.880\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.946\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 19: 100%|██████████| 403/403 [02:27<00:00,  2.74it/s, loss=20.6627]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000163  loss: 18.1969 (18.4216)  loss_mal: 0.6689 (0.7059)  loss_bbox: 0.1912 (0.2243)  loss_giou: 0.2931 (0.3384)  loss_fgl: 1.0259 (1.0403)  loss_mal_aux_0: 0.7114 (0.7711)  loss_bbox_aux_0: 0.1940 (0.2396)  loss_giou_aux_0: 0.3187 (0.3641)  loss_fgl_aux_0: 1.0951 (1.0946)  loss_ddf_aux_0: 0.0787 (0.0923)  loss_mal_aux_1: 0.6821 (0.7209)  loss_bbox_aux_1: 0.1868 (0.2253)  loss_giou_aux_1: 0.2909 (0.3399)  loss_fgl_aux_1: 1.0311 (1.0422)  loss_ddf_aux_1: 0.0033 (0.0040)  loss_mal_pre: 0.7036 (0.7701)  loss_bbox_pre: 0.1962 (0.2390)  loss_giou_pre: 0.3194 (0.3629)  loss_mal_enc_0: 0.8369 (0.8687)  loss_bbox_enc_0: 0.3076 (0.3229)  loss_giou_enc_0: 0.5046 (0.4853)  loss_mal_dn_0: 0.6514 (0.6437)  loss_bbox_dn_0: 0.2567 (0.2613)  loss_giou_dn_0: 0.3493 (0.3937)  loss_fgl_dn_0: 1.1500 (1.1547)  loss_ddf_dn_0: 0.2235 (0.2396)  loss_mal_dn_1: 0.5435 (0.5383)  loss_bbox_dn_1: 0.1929 (0.2129)  loss_giou_dn_1: 0.2866 (0.3117)  loss_fgl_dn_1: 1.0215 (1.0319)  loss_ddf_dn_1: 0.0080 (0.0085)  loss_mal_dn_2: 0.5410 (0.5306)  loss_bbox_dn_2: 0.1900 (0.2099)  loss_giou_dn_2: 0.2844 (0.3071)  loss_fgl_dn_2: 1.0180 (1.0279)  loss_mal_dn_pre: 0.6504 (0.6429)  loss_bbox_dn_pre: 0.2626 (0.2622)  loss_giou_dn_pre: 0.3505 (0.3929)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.44it/s]\n",
+      "\u001b[32m2025-04-03 21:52:39.404\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 15, 'coco_eval_bbox': 0.7564426878028832}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:52:39.405\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 20/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.754\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.936\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.867\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.570\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.779\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.755\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.831\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.858\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.694\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.881\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.951\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 20: 100%|██████████| 403/403 [02:29<00:00,  2.69it/s, loss=15.8849]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000150  loss: 15.8849 (17.9574)  loss_mal: 0.6152 (0.6703)  loss_bbox: 0.1689 (0.2214)  loss_giou: 0.2844 (0.3260)  loss_fgl: 1.0422 (1.0251)  loss_mal_aux_0: 0.6802 (0.7370)  loss_bbox_aux_0: 0.1987 (0.2367)  loss_giou_aux_0: 0.3054 (0.3513)  loss_fgl_aux_0: 1.0892 (1.0805)  loss_ddf_aux_0: 0.0794 (0.0926)  loss_mal_aux_1: 0.5957 (0.6852)  loss_bbox_aux_1: 0.1696 (0.2225)  loss_giou_aux_1: 0.2902 (0.3274)  loss_fgl_aux_1: 1.0394 (1.0270)  loss_ddf_aux_1: 0.0035 (0.0039)  loss_mal_pre: 0.6787 (0.7363)  loss_bbox_pre: 0.1947 (0.2364)  loss_giou_pre: 0.3031 (0.3501)  loss_mal_enc_0: 0.7681 (0.8416)  loss_bbox_enc_0: 0.2533 (0.3107)  loss_giou_enc_0: 0.3954 (0.4547)  loss_mal_dn_0: 0.6099 (0.6318)  loss_bbox_dn_0: 0.1812 (0.2565)  loss_giou_dn_0: 0.3357 (0.3808)  loss_fgl_dn_0: 1.1353 (1.1453)  loss_ddf_dn_0: 0.2253 (0.2443)  loss_mal_dn_1: 0.5024 (0.5243)  loss_bbox_dn_1: 0.1449 (0.2084)  loss_giou_dn_1: 0.2589 (0.3009)  loss_fgl_dn_1: 1.0256 (1.0184)  loss_ddf_dn_1: 0.0074 (0.0083)  loss_mal_dn_2: 0.4910 (0.5162)  loss_bbox_dn_2: 0.1413 (0.2053)  loss_giou_dn_2: 0.2552 (0.2966)  loss_fgl_dn_2: 1.0217 (1.0144)  loss_mal_dn_pre: 0.6069 (0.6311)  loss_bbox_dn_pre: 0.1849 (0.2579)  loss_giou_dn_pre: 0.3324 (0.3801)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.36it/s]\n",
+      "\u001b[32m2025-04-03 21:55:13.943\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 15, 'coco_eval_bbox': 0.7564426878028832}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:55:13.943\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 21/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.755\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.938\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.866\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.580\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.780\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.756\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.831\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.856\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.688\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.879\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.948\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 21: 100%|██████████| 403/403 [02:26<00:00,  2.75it/s, loss=14.8098]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000137  loss: 15.9672 (17.8664)  loss_mal: 0.5620 (0.6703)  loss_bbox: 0.1941 (0.2187)  loss_giou: 0.3436 (0.3258)  loss_fgl: 0.9852 (1.0242)  loss_mal_aux_0: 0.6499 (0.7328)  loss_bbox_aux_0: 0.2008 (0.2317)  loss_giou_aux_0: 0.3679 (0.3487)  loss_fgl_aux_0: 1.0657 (1.0767)  loss_ddf_aux_0: 0.0840 (0.0842)  loss_mal_aux_1: 0.5688 (0.6861)  loss_bbox_aux_1: 0.1942 (0.2196)  loss_giou_aux_1: 0.3412 (0.3272)  loss_fgl_aux_1: 0.9893 (1.0258)  loss_ddf_aux_1: 0.0033 (0.0036)  loss_mal_pre: 0.6470 (0.7321)  loss_bbox_pre: 0.2015 (0.2313)  loss_giou_pre: 0.3696 (0.3478)  loss_mal_enc_0: 0.8413 (0.8400)  loss_bbox_enc_0: 0.2617 (0.3086)  loss_giou_enc_0: 0.4640 (0.4593)  loss_mal_dn_0: 0.5835 (0.6294)  loss_bbox_dn_0: 0.2006 (0.2512)  loss_giou_dn_0: 0.3600 (0.3773)  loss_fgl_dn_0: 1.1325 (1.1426)  loss_ddf_dn_0: 0.2502 (0.2373)  loss_mal_dn_1: 0.4639 (0.5221)  loss_bbox_dn_1: 0.1561 (0.2046)  loss_giou_dn_1: 0.2814 (0.2988)  loss_fgl_dn_1: 0.9738 (1.0178)  loss_ddf_dn_1: 0.0074 (0.0079)  loss_mal_dn_2: 0.4595 (0.5145)  loss_bbox_dn_2: 0.1547 (0.2017)  loss_giou_dn_2: 0.2787 (0.2947)  loss_fgl_dn_2: 0.9716 (1.0139)  loss_mal_dn_pre: 0.5806 (0.6287)  loss_bbox_dn_pre: 0.1988 (0.2527)  loss_giou_dn_pre: 0.3548 (0.3769)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.58it/s]\n",
+      "\u001b[32m2025-04-03 21:57:45.447\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 15, 'coco_eval_bbox': 0.7564426878028832}\u001b[0m\n",
+      "\u001b[32m2025-04-03 21:57:45.448\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 22/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.753\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.936\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.867\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.561\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.778\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.752\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.830\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.854\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.698\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.877\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.946\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 22: 100%|██████████| 403/403 [02:44<00:00,  2.45it/s, loss=13.3271]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000125  loss: 15.3005 (17.6047)  loss_mal: 0.5840 (0.6581)  loss_bbox: 0.1579 (0.2156)  loss_giou: 0.2382 (0.3184)  loss_fgl: 0.9761 (1.0170)  loss_mal_aux_0: 0.6548 (0.7240)  loss_bbox_aux_0: 0.2000 (0.2300)  loss_giou_aux_0: 0.2617 (0.3428)  loss_fgl_aux_0: 1.0290 (1.0698)  loss_ddf_aux_0: 0.0954 (0.0867)  loss_mal_aux_1: 0.5674 (0.6728)  loss_bbox_aux_1: 0.1583 (0.2164)  loss_giou_aux_1: 0.2421 (0.3197)  loss_fgl_aux_1: 0.9732 (1.0187)  loss_ddf_aux_1: 0.0041 (0.0036)  loss_mal_pre: 0.6621 (0.7222)  loss_bbox_pre: 0.1989 (0.2299)  loss_giou_pre: 0.2676 (0.3418)  loss_mal_enc_0: 0.8140 (0.8223)  loss_bbox_enc_0: 0.2339 (0.2981)  loss_giou_enc_0: 0.3836 (0.4388)  loss_mal_dn_0: 0.5747 (0.6217)  loss_bbox_dn_0: 0.2135 (0.2436)  loss_giou_dn_0: 0.2814 (0.3667)  loss_fgl_dn_0: 1.1162 (1.1347)  loss_ddf_dn_0: 0.2533 (0.2431)  loss_mal_dn_1: 0.4475 (0.5143)  loss_bbox_dn_1: 0.1405 (0.1981)  loss_giou_dn_1: 0.2058 (0.2909)  loss_fgl_dn_1: 0.9721 (1.0104)  loss_ddf_dn_1: 0.0079 (0.0074)  loss_mal_dn_2: 0.4463 (0.5071)  loss_bbox_dn_2: 0.1384 (0.1954)  loss_giou_dn_2: 0.2031 (0.2869)  loss_fgl_dn_2: 0.9651 (1.0064)  loss_mal_dn_pre: 0.5737 (0.6209)  loss_bbox_dn_pre: 0.2204 (0.2448)  loss_giou_dn_pre: 0.2803 (0.3660)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.92it/s]\n",
+      "\u001b[32m2025-04-03 22:00:35.472\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 15, 'coco_eval_bbox': 0.7564426878028832}\u001b[0m\n",
+      "\u001b[32m2025-04-03 22:00:35.473\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 23/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.08s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.755\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.938\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.869\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.568\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.781\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.753\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.826\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.853\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.691\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.876\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.946\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 23: 100%|██████████| 403/403 [02:45<00:00,  2.43it/s, loss=18.9006]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000115  loss: 15.4950 (17.2954)  loss_mal: 0.5771 (0.6394)  loss_bbox: 0.1661 (0.2108)  loss_giou: 0.2864 (0.3120)  loss_fgl: 0.9641 (1.0105)  loss_mal_aux_0: 0.6587 (0.7040)  loss_bbox_aux_0: 0.2104 (0.2241)  loss_giou_aux_0: 0.3072 (0.3356)  loss_fgl_aux_0: 1.0514 (1.0651)  loss_ddf_aux_0: 0.0917 (0.0865)  loss_mal_aux_1: 0.5972 (0.6520)  loss_bbox_aux_1: 0.1762 (0.2118)  loss_giou_aux_1: 0.2892 (0.3137)  loss_fgl_aux_1: 0.9736 (1.0128)  loss_ddf_aux_1: 0.0036 (0.0039)  loss_mal_pre: 0.6450 (0.7037)  loss_bbox_pre: 0.2070 (0.2230)  loss_giou_pre: 0.3055 (0.3343)  loss_mal_enc_0: 0.7852 (0.8005)  loss_bbox_enc_0: 0.2726 (0.2845)  loss_giou_enc_0: 0.4349 (0.4246)  loss_mal_dn_0: 0.5977 (0.6159)  loss_bbox_dn_0: 0.2266 (0.2357)  loss_giou_dn_0: 0.3033 (0.3573)  loss_fgl_dn_0: 1.1055 (1.1292)  loss_ddf_dn_0: 0.2253 (0.2349)  loss_mal_dn_1: 0.4675 (0.5062)  loss_bbox_dn_1: 0.1612 (0.1917)  loss_giou_dn_1: 0.2399 (0.2834)  loss_fgl_dn_1: 0.9780 (1.0039)  loss_ddf_dn_1: 0.0071 (0.0079)  loss_mal_dn_2: 0.4612 (0.4989)  loss_bbox_dn_2: 0.1524 (0.1887)  loss_giou_dn_2: 0.2387 (0.2792)  loss_fgl_dn_2: 0.9750 (0.9998)  loss_mal_dn_pre: 0.5938 (0.6153)  loss_bbox_dn_pre: 0.2313 (0.2375)  loss_giou_dn_pre: 0.3031 (0.3569)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.61it/s]\n",
+      "\u001b[32m2025-04-03 22:03:26.898\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 15, 'coco_eval_bbox': 0.7564426878028832}\u001b[0m\n",
+      "\u001b[32m2025-04-03 22:03:26.899\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 24/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.752\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.937\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.864\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.562\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.777\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.752\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.826\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.851\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.664\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.875\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.983\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.946\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 24: 100%|██████████| 403/403 [02:37<00:00,  2.56it/s, loss=15.2482]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000107  loss: 15.8278 (17.0718)  loss_mal: 0.5669 (0.6287)  loss_bbox: 0.1428 (0.2037)  loss_giou: 0.2277 (0.3085)  loss_fgl: 0.9997 (1.0002)  loss_mal_aux_0: 0.6738 (0.6925)  loss_bbox_aux_0: 0.1719 (0.2170)  loss_giou_aux_0: 0.2584 (0.3308)  loss_fgl_aux_0: 1.0436 (1.0515)  loss_ddf_aux_0: 0.0775 (0.0834)  loss_mal_aux_1: 0.5845 (0.6435)  loss_bbox_aux_1: 0.1470 (0.2045)  loss_giou_aux_1: 0.2347 (0.3097)  loss_fgl_aux_1: 1.0003 (1.0022)  loss_ddf_aux_1: 0.0031 (0.0038)  loss_mal_pre: 0.6709 (0.6923)  loss_bbox_pre: 0.1753 (0.2168)  loss_giou_pre: 0.2599 (0.3297)  loss_mal_enc_0: 0.7651 (0.7922)  loss_bbox_enc_0: 0.2583 (0.2774)  loss_giou_enc_0: 0.3557 (0.4185)  loss_mal_dn_0: 0.5918 (0.6082)  loss_bbox_dn_0: 0.1973 (0.2331)  loss_giou_dn_0: 0.2981 (0.3533)  loss_fgl_dn_0: 1.1224 (1.1220)  loss_ddf_dn_0: 0.2304 (0.2345)  loss_mal_dn_1: 0.4617 (0.5003)  loss_bbox_dn_1: 0.1570 (0.1887)  loss_giou_dn_1: 0.2270 (0.2808)  loss_fgl_dn_1: 0.9893 (0.9949)  loss_ddf_dn_1: 0.0069 (0.0076)  loss_mal_dn_2: 0.4626 (0.4926)  loss_bbox_dn_2: 0.1535 (0.1859)  loss_giou_dn_2: 0.2246 (0.2769)  loss_fgl_dn_2: 0.9935 (0.9909)  loss_mal_dn_pre: 0.5898 (0.6075)  loss_bbox_dn_pre: 0.2047 (0.2349)  loss_giou_dn_pre: 0.2972 (0.3529)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.50it/s]\n",
+      "\u001b[32m2025-04-03 22:06:09.330\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 15, 'coco_eval_bbox': 0.7564426878028832}\u001b[0m\n",
+      "\u001b[32m2025-04-03 22:06:09.330\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 25/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.755\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.939\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.866\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.558\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.780\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.753\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.827\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.849\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.664\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.873\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.983\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.946\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 25: 100%|██████████| 403/403 [02:28<00:00,  2.71it/s, loss=12.6402]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000102  loss: 14.0983 (16.9975)  loss_mal: 0.4976 (0.6265)  loss_bbox: 0.1304 (0.2037)  loss_giou: 0.2113 (0.3053)  loss_fgl: 0.9336 (0.9998)  loss_mal_aux_0: 0.5562 (0.6901)  loss_bbox_aux_0: 0.1439 (0.2162)  loss_giou_aux_0: 0.2265 (0.3264)  loss_fgl_aux_0: 0.9912 (1.0482)  loss_ddf_aux_0: 0.0758 (0.0789)  loss_mal_aux_1: 0.4983 (0.6391)  loss_bbox_aux_1: 0.1308 (0.2045)  loss_giou_aux_1: 0.2137 (0.3064)  loss_fgl_aux_1: 0.9360 (1.0017)  loss_ddf_aux_1: 0.0031 (0.0033)  loss_mal_pre: 0.5547 (0.6894)  loss_bbox_pre: 0.1424 (0.2160)  loss_giou_pre: 0.2267 (0.3254)  loss_mal_enc_0: 0.7144 (0.7895)  loss_bbox_enc_0: 0.1816 (0.2741)  loss_giou_enc_0: 0.3255 (0.4138)  loss_mal_dn_0: 0.5479 (0.6070)  loss_bbox_dn_0: 0.1669 (0.2331)  loss_giou_dn_0: 0.2627 (0.3503)  loss_fgl_dn_0: 1.0858 (1.1176)  loss_ddf_dn_0: 0.2313 (0.2327)  loss_mal_dn_1: 0.4246 (0.4978)  loss_bbox_dn_1: 0.1198 (0.1900)  loss_giou_dn_1: 0.1872 (0.2793)  loss_fgl_dn_1: 0.9241 (0.9917)  loss_ddf_dn_1: 0.0069 (0.0073)  loss_mal_dn_2: 0.4172 (0.4905)  loss_bbox_dn_2: 0.1178 (0.1873)  loss_giou_dn_2: 0.1860 (0.2755)  loss_fgl_dn_2: 0.9183 (0.9877)  loss_mal_dn_pre: 0.5483 (0.6064)  loss_bbox_dn_pre: 0.1665 (0.2348)  loss_giou_dn_pre: 0.2616 (0.3500)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.40it/s]\n",
+      "\u001b[32m2025-04-03 22:08:43.054\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 15, 'coco_eval_bbox': 0.7564426878028832}\u001b[0m\n",
+      "\u001b[32m2025-04-03 22:08:43.055\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 26/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.756\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.939\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.871\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.563\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.782\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.754\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.825\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.847\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.664\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.870\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.983\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.944\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 26: 100%|██████████| 403/403 [02:30<00:00,  2.68it/s, loss=14.8032]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 18.7728 (16.8171)  loss_mal: 0.7183 (0.6201)  loss_bbox: 0.2123 (0.1957)  loss_giou: 0.3541 (0.3014)  loss_fgl: 1.0298 (0.9948)  loss_mal_aux_0: 0.7910 (0.6776)  loss_bbox_aux_0: 0.2346 (0.2073)  loss_giou_aux_0: 0.3762 (0.3223)  loss_fgl_aux_0: 1.0804 (1.0450)  loss_ddf_aux_0: 0.0826 (0.0800)  loss_mal_aux_1: 0.7422 (0.6333)  loss_bbox_aux_1: 0.2165 (0.1965)  loss_giou_aux_1: 0.3545 (0.3028)  loss_fgl_aux_1: 1.0304 (0.9970)  loss_ddf_aux_1: 0.0039 (0.0035)  loss_mal_pre: 0.7905 (0.6778)  loss_bbox_pre: 0.2322 (0.2072)  loss_giou_pre: 0.3775 (0.3215)  loss_mal_enc_0: 0.8286 (0.7789)  loss_bbox_enc_0: 0.2908 (0.2659)  loss_giou_enc_0: 0.4605 (0.4109)  loss_mal_dn_0: 0.6646 (0.6029)  loss_bbox_dn_0: 0.2548 (0.2275)  loss_giou_dn_0: 0.4193 (0.3466)  loss_fgl_dn_0: 1.1236 (1.1164)  loss_ddf_dn_0: 0.2232 (0.2355)  loss_mal_dn_1: 0.5469 (0.4930)  loss_bbox_dn_1: 0.2211 (0.1844)  loss_giou_dn_1: 0.3367 (0.2752)  loss_fgl_dn_1: 1.0245 (0.9881)  loss_ddf_dn_1: 0.0085 (0.0075)  loss_mal_dn_2: 0.5444 (0.4859)  loss_bbox_dn_2: 0.2221 (0.1818)  loss_giou_dn_2: 0.3290 (0.2712)  loss_fgl_dn_2: 1.0243 (0.9838)  loss_mal_dn_pre: 0.6636 (0.6024)  loss_bbox_dn_pre: 0.2575 (0.2288)  loss_giou_dn_pre: 0.4182 (0.3462)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.43it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.758\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.939\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.872\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.568\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.783\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.755\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.827\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.848\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.664\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.872\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.983\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.944\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 22:11:18.511\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 22:11:18.512\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 26 / mAP: 0.7580810398692926\u001b[0m\n",
+      "\u001b[32m2025-04-03 22:11:18.513\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 26, 'coco_eval_bbox': 0.7580810398692926}\u001b[0m\n",
+      "\u001b[32m2025-04-03 22:11:18.514\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 27/30\u001b[0m\n",
+      "Epoch 27: 100%|██████████| 403/403 [02:31<00:00,  2.67it/s, loss=15.8156]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 18.5853 (16.9391)  loss_mal: 0.7373 (0.6309)  loss_bbox: 0.1907 (0.2015)  loss_giou: 0.3578 (0.3068)  loss_fgl: 1.0085 (0.9986)  loss_mal_aux_0: 0.7598 (0.6869)  loss_bbox_aux_0: 0.1908 (0.2129)  loss_giou_aux_0: 0.3862 (0.3273)  loss_fgl_aux_0: 1.0392 (1.0451)  loss_ddf_aux_0: 0.0691 (0.0782)  loss_mal_aux_1: 0.7588 (0.6445)  loss_bbox_aux_1: 0.1888 (0.2025)  loss_giou_aux_1: 0.3602 (0.3082)  loss_fgl_aux_1: 1.0063 (1.0007)  loss_ddf_aux_1: 0.0033 (0.0038)  loss_mal_pre: 0.7471 (0.6864)  loss_bbox_pre: 0.1935 (0.2127)  loss_giou_pre: 0.3794 (0.3265)  loss_mal_enc_0: 0.7998 (0.7767)  loss_bbox_enc_0: 0.2983 (0.2668)  loss_giou_enc_0: 0.4626 (0.4095)  loss_mal_dn_0: 0.6548 (0.6052)  loss_bbox_dn_0: 0.2384 (0.2298)  loss_giou_dn_0: 0.4170 (0.3494)  loss_fgl_dn_0: 1.1262 (1.1150)  loss_ddf_dn_0: 0.2239 (0.2335)  loss_mal_dn_1: 0.5566 (0.4975)  loss_bbox_dn_1: 0.1921 (0.1864)  loss_giou_dn_1: 0.3427 (0.2787)  loss_fgl_dn_1: 1.0288 (0.9899)  loss_ddf_dn_1: 0.0073 (0.0078)  loss_mal_dn_2: 0.5459 (0.4905)  loss_bbox_dn_2: 0.1905 (0.1838)  loss_giou_dn_2: 0.3364 (0.2746)  loss_fgl_dn_2: 1.0277 (0.9858)  loss_mal_dn_pre: 0.6548 (0.6046)  loss_bbox_dn_pre: 0.2427 (0.2314)  loss_giou_dn_pre: 0.4149 (0.3489)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.26it/s]\n",
+      "\u001b[32m2025-04-03 22:13:54.596\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 26, 'coco_eval_bbox': 0.7580810398692926}\u001b[0m\n",
+      "\u001b[32m2025-04-03 22:13:54.596\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 28/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.08s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.758\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.938\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.871\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.567\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.783\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.755\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.826\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.847\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.663\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.871\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.944\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 28: 100%|██████████| 403/403 [02:29<00:00,  2.69it/s, loss=17.8688]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 17.8688 (16.7956)  loss_mal: 0.7007 (0.6240)  loss_bbox: 0.2133 (0.1999)  loss_giou: 0.3395 (0.3005)  loss_fgl: 0.9896 (0.9952)  loss_mal_aux_0: 0.7612 (0.6772)  loss_bbox_aux_0: 0.2178 (0.2117)  loss_giou_aux_0: 0.3528 (0.3200)  loss_fgl_aux_0: 1.0348 (1.0418)  loss_ddf_aux_0: 0.0771 (0.0751)  loss_mal_aux_1: 0.7109 (0.6367)  loss_bbox_aux_1: 0.2150 (0.2007)  loss_giou_aux_1: 0.3411 (0.3017)  loss_fgl_aux_1: 0.9957 (0.9971)  loss_ddf_aux_1: 0.0034 (0.0036)  loss_mal_pre: 0.7578 (0.6773)  loss_bbox_pre: 0.2143 (0.2115)  loss_giou_pre: 0.3516 (0.3191)  loss_mal_enc_0: 0.8091 (0.7760)  loss_bbox_enc_0: 0.2516 (0.2659)  loss_giou_enc_0: 0.4302 (0.4007)  loss_mal_dn_0: 0.6284 (0.6016)  loss_bbox_dn_0: 0.2574 (0.2282)  loss_giou_dn_0: 0.3779 (0.3434)  loss_fgl_dn_0: 1.1205 (1.1121)  loss_ddf_dn_0: 0.2222 (0.2298)  loss_mal_dn_1: 0.5493 (0.4934)  loss_bbox_dn_1: 0.2188 (0.1854)  loss_giou_dn_1: 0.3137 (0.2743)  loss_fgl_dn_1: 1.0091 (0.9871)  loss_ddf_dn_1: 0.0085 (0.0073)  loss_mal_dn_2: 0.5405 (0.4862)  loss_bbox_dn_2: 0.2111 (0.1828)  loss_giou_dn_2: 0.3094 (0.2705)  loss_fgl_dn_2: 1.0063 (0.9833)  loss_mal_dn_pre: 0.6299 (0.6011)  loss_bbox_dn_pre: 0.2571 (0.2301)  loss_giou_dn_pre: 0.3792 (0.3431)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.19it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.760\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.939\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.872\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.567\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.785\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.757\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.828\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.850\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.674\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.874\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.951\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 22:16:29.835\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 22:16:29.838\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 28 / mAP: 0.7595313026974617\u001b[0m\n",
+      "\u001b[32m2025-04-03 22:16:29.839\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 28, 'coco_eval_bbox': 0.7595313026974617}\u001b[0m\n",
+      "\u001b[32m2025-04-03 22:16:29.840\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 29/30\u001b[0m\n",
+      "Epoch 29: 100%|██████████| 403/403 [02:43<00:00,  2.47it/s, loss=16.3756]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 17.9363 (16.6991)  loss_mal: 0.7114 (0.6088)  loss_bbox: 0.1932 (0.1989)  loss_giou: 0.3335 (0.2993)  loss_fgl: 1.0021 (0.9955)  loss_mal_aux_0: 0.7686 (0.6703)  loss_bbox_aux_0: 0.1977 (0.2107)  loss_giou_aux_0: 0.3601 (0.3190)  loss_fgl_aux_0: 1.0700 (1.0406)  loss_ddf_aux_0: 0.0617 (0.0721)  loss_mal_aux_1: 0.7119 (0.6253)  loss_bbox_aux_1: 0.1925 (0.1998)  loss_giou_aux_1: 0.3370 (0.3007)  loss_fgl_aux_1: 1.0055 (0.9974)  loss_ddf_aux_1: 0.0035 (0.0036)  loss_mal_pre: 0.7676 (0.6700)  loss_bbox_pre: 0.1955 (0.2103)  loss_giou_pre: 0.3634 (0.3180)  loss_mal_enc_0: 0.8315 (0.7700)  loss_bbox_enc_0: 0.2532 (0.2628)  loss_giou_enc_0: 0.4028 (0.3990)  loss_mal_dn_0: 0.6177 (0.5992)  loss_bbox_dn_0: 0.2262 (0.2257)  loss_giou_dn_0: 0.3957 (0.3416)  loss_fgl_dn_0: 1.1261 (1.1122)  loss_ddf_dn_0: 0.2142 (0.2252)  loss_mal_dn_1: 0.5283 (0.4898)  loss_bbox_dn_1: 0.1945 (0.1828)  loss_giou_dn_1: 0.3228 (0.2721)  loss_fgl_dn_1: 1.0103 (0.9879)  loss_ddf_dn_1: 0.0067 (0.0071)  loss_mal_dn_2: 0.5278 (0.4830)  loss_bbox_dn_2: 0.1927 (0.1803)  loss_giou_dn_2: 0.3187 (0.2686)  loss_fgl_dn_2: 1.0059 (0.9840)  loss_mal_dn_pre: 0.6167 (0.5986)  loss_bbox_dn_pre: 0.2250 (0.2274)  loss_giou_dn_pre: 0.3939 (0.3414)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.04it/s]\n",
+      "\u001b[32m2025-04-03 22:19:18.228\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 28, 'coco_eval_bbox': 0.7595313026974617}\u001b[0m\n",
+      "\u001b[32m2025-04-03 22:19:18.228\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m555\u001b[0m - \u001b[1mTraining completed in 1:17:20\u001b[0m\n",
+      "\u001b[32m2025-04-03 22:19:18.229\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m556\u001b[0m - \u001b[1mBest stats: {'epoch': 28, 'coco_eval_bbox': 0.7595313026974617}\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.758\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.938\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.870\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.567\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.784\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.756\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.826\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.849\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.674\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.873\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.948\n"
+     ]
+    }
+   ],
+   "source": [
+    "from deimkit import Config, Trainer, configure_dataset, configure_model\n",
+    "\n",
+    "conf = Config.from_model_name(\"deim_hgnetv2_s\")\n",
+    "\n",
+    "conf = configure_model(conf, num_queries=100, freeze_at=0, pretrained=True)\n",
+    "\n",
+    "conf = configure_dataset(\n",
+    "    config=conf,\n",
+    "    image_size=(640, 640),\n",
+    "    train_ann_file=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train/_annotations.coco.json\",\n",
+    "    train_img_folder=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train\",\n",
+    "    val_ann_file=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid/_annotations.coco.json\",\n",
+    "    val_img_folder=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid\",\n",
+    "    train_batch_size=16,\n",
+    "    val_batch_size=16,\n",
+    "    num_classes=4,\n",
+    "    remap_mscoco=False,\n",
+    "    output_dir=\"./outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_progressive_resizing\",\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(conf)\n",
+    "\n",
+    "trainer.load_checkpoint(\"./outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\")\n",
+    "trainer.fit(epochs=30, save_best_only=True)\n"
    ]
   },
   {

--- a/nbs/progressive-resising.ipynb
+++ b/nbs/progressive-resising.ipynb
@@ -1,0 +1,2617 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The aim of this notebook is to test the progressive resizing strategy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train at 128px for 10 epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:28:42.355\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.DFINETransformer.num_queries' to: 100\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.356\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.PostProcessor.num_top_queries' to: 100\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.356\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.HGNetv2.pretrained' to: True\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.356\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.HGNetv2.freeze_at' to: 0\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.402\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_init_process_group\u001b[0m:\u001b[36m60\u001b[0m - \u001b[1mInitializing process group for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.404\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_init_process_group\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mProcess group initialized successfully\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.405\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m239\u001b[0m - \u001b[1mStarting training...\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.405\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m242\u001b[0m - \u001b[1mOverriding epochs to 10\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.406\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m276\u001b[0m - \u001b[1mSetting pretrained flag to True for HGNetv2\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.406\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m296\u001b[0m - \u001b[1mAutomatically calculated mixup epochs: [1, 5]\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.406\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m306\u001b[0m - \u001b[1mAutomatically calculated data augmentation epochs: 1, 5, 9\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.406\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m315\u001b[0m - \u001b[1mAutomatically calculated stop epoch: 9\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.407\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m323\u001b[0m - \u001b[1mAutomatically calculated no augmentation epochs: 1\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.407\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m336\u001b[0m - \u001b[1mAutomatically calculated flat epochs: 5\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.410\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m363\u001b[0m - \u001b[1mAutomatically calculated warmup iterations: 403 (1.0 epochs)\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.410\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m376\u001b[0m - \u001b[1mAutomatically calculated EMA warmups: 403 (1.0 epochs)\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.411\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m152\u001b[0m - \u001b[1mDisabling sync_bn and find_unused_parameters for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.411\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m164\u001b[0m - \u001b[1mSet device in config: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.411\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m174\u001b[0m - \u001b[1mInitializing solver for task: detection\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded stage1 B0 HGNetV2 from local file.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/dnth/Desktop/DEIMKit/src/deimkit/engine/core/workspace.py:180: FutureWarning: `torch.cuda.amp.GradScaler(args...)` is deprecated. Please use `torch.amp.GradScaler('cuda', args...)` instead.\n",
+      "  return module(**module_kwargs)\n",
+      "\u001b[32m2025-04-03 14:28:42.894\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m201\u001b[0m - \u001b[1mTraining setup complete. Output directory: outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.895\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m203\u001b[0m - \u001b[1mSaving config to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/config.yml\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:42.903\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m384\u001b[0m - \u001b[1mUsing device: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:43.026\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:43.027\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m393\u001b[0m - \u001b[1mInitial model saved as best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:43.028\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m403\u001b[0m - \u001b[1mNumber of trainable parameters: 10217817\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:43.029\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m409\u001b[0m - \u001b[1mUsing custom scheduler: flatcosine\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:28:43.029\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 0/10\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial lr: [0.0002, 0.0004, 0.0004]\n",
+      "building train_dataloader with batch_size=16...\n",
+      "     ### Transform @Mosaic ###    \n",
+      "     ### Transform @RandomPhotometricDistort ###    \n",
+      "     ### Transform @RandomZoomOut ###    \n",
+      "     ### Transform @RandomIoUCrop ###    \n",
+      "     ### Transform @SanitizeBoundingBoxes ###    \n",
+      "     ### Transform @RandomHorizontalFlip ###    \n",
+      "     ### Transform @Resize ###    \n",
+      "     ### Transform @SanitizeBoundingBoxes ###    \n",
+      "     ### Transform @ConvertPILImage ###    \n",
+      "     ### Transform @ConvertBoxes ###    \n",
+      "     ### Mosaic with Prob.@0.5 and ZoomOut/IoUCrop existed ### \n",
+      "     ### ImgTransforms Epochs: [1, 5, 9] ### \n",
+      "     ### Policy_ops@['Mosaic', 'RandomPhotometricDistort', 'RandomZoomOut', 'RandomIoUCrop'] ###\n",
+      "     ### Using MixUp with Prob@0.5 in [1, 5] epochs ### \n",
+      "     ### Multi-scale Training until 9 epochs ### \n",
+      "     ### Multi-scales@ [96, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 160] ###        \n",
+      "building val_dataloader with batch_size=16...\n",
+      "     ### Transform @Resize ###    \n",
+      "     ### Transform @ConvertPILImage ###    \n",
+      "[0.0002, 0.0004, 0.0004] [0.0001, 0.0002, 0.0002] 4030 403 2015 403\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 403/403 [01:12<00:00,  5.58it/s, loss=31.8230]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000199  loss: 33.3829 (39.1596)  loss_mal: 1.7744 (1.1150)  loss_bbox: 0.6207 (1.6377)  loss_giou: 0.5784 (1.2010)  loss_fgl: 1.2619 (0.8419)  loss_mal_aux_0: 1.5762 (1.0511)  loss_bbox_aux_0: 0.6617 (1.6652)  loss_giou_aux_0: 0.6207 (1.2228)  loss_fgl_aux_0: 1.2456 (0.8445)  loss_mal_aux_1: 1.6826 (1.0775)  loss_bbox_aux_1: 0.6528 (1.6499)  loss_giou_aux_1: 0.6150 (1.2112)  loss_fgl_aux_1: 1.2573 (0.8424)  loss_mal_pre: 1.5498 (1.0360)  loss_bbox_pre: 0.6626 (1.6757)  loss_giou_pre: 0.6109 (1.2275)  loss_mal_enc_0: 1.2812 (0.9584)  loss_bbox_enc_0: 1.1488 (1.8270)  loss_giou_enc_0: 0.9773 (1.3395)  loss_mal_dn_0: 0.7905 (0.8399)  loss_bbox_dn_0: 1.0637 (1.4471)  loss_giou_dn_0: 0.8955 (1.2364)  loss_fgl_dn_0: 1.1151 (0.9050)  loss_mal_dn_1: 0.7656 (0.8051)  loss_bbox_dn_1: 1.0062 (1.4335)  loss_giou_dn_1: 0.8753 (1.2316)  loss_fgl_dn_1: 1.1129 (0.9027)  loss_mal_dn_2: 0.7974 (0.8108)  loss_bbox_dn_2: 0.9348 (1.4187)  loss_giou_dn_2: 0.8050 (1.2191)  loss_fgl_dn_2: 1.1289 (0.9075)  loss_mal_dn_pre: 0.7905 (0.8407)  loss_bbox_dn_pre: 1.0606 (1.4641)  loss_giou_dn_pre: 0.8919 (1.2363)  loss_ddf_aux_0: 0.0282 (0.0144)  loss_ddf_aux_1: 0.0126 (0.0041)  loss_ddf_dn_0: 0.0351 (0.0141)  loss_ddf_dn_1: 0.0187 (0.0048)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 15.33it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.101\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.221\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.075\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.093\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.112\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.348\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.535\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.601\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.256\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.645\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.947\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.657\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:29:57.898\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:29:57.899\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 0 / mAP: 0.10130532838347801\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:29:57.900\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 0, 'coco_eval_bbox': 0.10130532838347801}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:29:57.900\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 1/10\u001b[0m\n",
+      "Epoch 1: 100%|██████████| 403/403 [01:27<00:00,  4.58it/s, loss=29.8709]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 29.8709 (30.9488)  loss_mal: 1.2617 (1.3347)  loss_bbox: 0.5714 (0.6373)  loss_giou: 0.8725 (0.9386)  loss_fgl: 1.0942 (1.0593)  loss_mal_aux_0: 1.2705 (1.2934)  loss_bbox_aux_0: 0.5838 (0.6428)  loss_giou_aux_0: 0.8864 (0.9509)  loss_fgl_aux_0: 1.0926 (1.0572)  loss_ddf_aux_0: 0.0164 (0.0179)  loss_mal_aux_1: 1.3223 (1.3216)  loss_bbox_aux_1: 0.5724 (0.6371)  loss_giou_aux_1: 0.8750 (0.9424)  loss_fgl_aux_1: 1.0938 (1.0581)  loss_ddf_aux_1: 0.0021 (0.0046)  loss_mal_pre: 1.2695 (1.2897)  loss_bbox_pre: 0.5786 (0.6401)  loss_giou_pre: 0.8854 (0.9500)  loss_mal_enc_0: 1.1875 (1.2199)  loss_bbox_enc_0: 0.6338 (0.7317)  loss_giou_enc_0: 0.9623 (1.0437)  loss_mal_dn_0: 0.7544 (0.7467)  loss_bbox_dn_0: 0.6393 (0.7217)  loss_giou_dn_0: 1.0265 (1.0891)  loss_fgl_dn_0: 1.0154 (0.9957)  loss_ddf_dn_0: 0.0583 (0.0393)  loss_mal_dn_1: 0.7676 (0.7579)  loss_bbox_dn_1: 0.6050 (0.6992)  loss_giou_dn_1: 0.9681 (1.0558)  loss_fgl_dn_1: 1.0213 (1.0022)  loss_ddf_dn_1: 0.0079 (0.0084)  loss_mal_dn_2: 0.7690 (0.7622)  loss_bbox_dn_2: 0.6077 (0.6920)  loss_giou_dn_2: 0.9574 (1.0429)  loss_fgl_dn_2: 1.0297 (1.0067)  loss_mal_dn_pre: 0.7534 (0.7459)  loss_bbox_dn_pre: 0.6494 (0.7232)  loss_giou_dn_pre: 1.0280 (1.0888)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 16.88it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.190\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.367\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.181\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.124\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.210\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.386\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.586\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.650\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.316\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.698\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.939\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.762\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:31:28.304\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:31:28.306\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 1 / mAP: 0.19035324202785167\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:31:28.307\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 1, 'coco_eval_bbox': 0.19035324202785167}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:31:28.307\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 2/10\u001b[0m\n",
+      "Epoch 2: 100%|██████████| 403/403 [01:28<00:00,  4.54it/s, loss=26.4475]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 28.7592 (29.4460)  loss_mal: 1.2188 (1.2884)  loss_bbox: 0.5466 (0.5429)  loss_giou: 0.8605 (0.8229)  loss_fgl: 1.0984 (1.1086)  loss_mal_aux_0: 1.2676 (1.2806)  loss_bbox_aux_0: 0.5509 (0.5556)  loss_giou_aux_0: 0.8617 (0.8410)  loss_fgl_aux_0: 1.0982 (1.1088)  loss_ddf_aux_0: 0.0214 (0.0260)  loss_mal_aux_1: 1.2930 (1.2940)  loss_bbox_aux_1: 0.5473 (0.5432)  loss_giou_aux_1: 0.8556 (0.8240)  loss_fgl_aux_1: 1.0951 (1.1083)  loss_ddf_aux_1: 0.0019 (0.0025)  loss_mal_pre: 1.2451 (1.2787)  loss_bbox_pre: 0.5486 (0.5545)  loss_giou_pre: 0.8613 (0.8399)  loss_mal_enc_0: 1.2539 (1.2478)  loss_bbox_enc_0: 0.5823 (0.6355)  loss_giou_enc_0: 0.9374 (0.9270)  loss_mal_dn_0: 0.7769 (0.7741)  loss_bbox_dn_0: 0.6160 (0.6357)  loss_giou_dn_0: 0.9413 (0.9675)  loss_fgl_dn_0: 1.0602 (1.0643)  loss_ddf_dn_0: 0.0689 (0.0811)  loss_mal_dn_1: 0.7871 (0.7926)  loss_bbox_dn_1: 0.5592 (0.5909)  loss_giou_dn_1: 0.8707 (0.9019)  loss_fgl_dn_1: 1.0756 (1.0764)  loss_ddf_dn_1: 0.0057 (0.0083)  loss_mal_dn_2: 0.7881 (0.7879)  loss_bbox_dn_2: 0.5563 (0.5864)  loss_giou_dn_2: 0.8650 (0.8934)  loss_fgl_dn_2: 1.0790 (1.0790)  loss_mal_dn_pre: 0.7769 (0.7738)  loss_bbox_dn_pre: 0.6140 (0.6361)  loss_giou_dn_pre: 0.9378 (0.9662)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 17.24it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.295\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.497\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.314\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.026\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.074\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.328\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.476\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.653\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.689\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.025\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.294\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.739\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.944\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.816\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:32:59.673\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:32:59.675\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 2 / mAP: 0.2948400366804452\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:32:59.676\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 2, 'coco_eval_bbox': 0.2948400366804452}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:32:59.676\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 3/10\u001b[0m\n",
+      "Epoch 3: 100%|██████████| 403/403 [01:36<00:00,  4.16it/s, loss=25.9623]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 26.9043 (28.4187)  loss_mal: 1.1396 (1.2073)  loss_bbox: 0.4422 (0.5063)  loss_giou: 0.7112 (0.7890)  loss_fgl: 1.1122 (1.1132)  loss_mal_aux_0: 1.1641 (1.2253)  loss_bbox_aux_0: 0.4593 (0.5196)  loss_giou_aux_0: 0.7318 (0.8075)  loss_fgl_aux_0: 1.1107 (1.1159)  loss_ddf_aux_0: 0.0228 (0.0247)  loss_mal_aux_1: 1.1855 (1.2253)  loss_bbox_aux_1: 0.4396 (0.5065)  loss_giou_aux_1: 0.7127 (0.7897)  loss_fgl_aux_1: 1.1112 (1.1135)  loss_ddf_aux_1: 0.0018 (0.0018)  loss_mal_pre: 1.1621 (1.2233)  loss_bbox_pre: 0.4574 (0.5188)  loss_giou_pre: 0.7309 (0.8060)  loss_mal_enc_0: 1.1992 (1.2192)  loss_bbox_enc_0: 0.5098 (0.5897)  loss_giou_enc_0: 0.7970 (0.8871)  loss_mal_dn_0: 0.7812 (0.7826)  loss_bbox_dn_0: 0.5000 (0.5819)  loss_giou_dn_0: 0.8297 (0.9044)  loss_fgl_dn_0: 1.1120 (1.0937)  loss_ddf_dn_0: 0.0999 (0.1005)  loss_mal_dn_1: 0.7939 (0.7927)  loss_bbox_dn_1: 0.4189 (0.5289)  loss_giou_dn_1: 0.7284 (0.8289)  loss_fgl_dn_1: 1.1072 (1.1024)  loss_ddf_dn_1: 0.0069 (0.0071)  loss_mal_dn_2: 0.7798 (0.7868)  loss_bbox_dn_2: 0.4150 (0.5251)  loss_giou_dn_2: 0.7208 (0.8227)  loss_fgl_dn_2: 1.1082 (1.1029)  loss_mal_dn_pre: 0.7812 (0.7823)  loss_bbox_dn_pre: 0.5012 (0.5825)  loss_giou_dn_pre: 0.8256 (0.9038)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 14.40it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.361\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.613\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.379\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.180\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.392\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.502\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.634\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.696\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.358\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.742\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.958\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.813\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:34:39.413\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:34:39.415\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 3 / mAP: 0.3606628641695955\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:34:39.416\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 3, 'coco_eval_bbox': 0.3606628641695955}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:34:39.417\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 4/10\u001b[0m\n",
+      "Epoch 4: 100%|██████████| 403/403 [01:34<00:00,  4.26it/s, loss=25.1240]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 25.9052 (27.6389)  loss_mal: 1.0967 (1.1710)  loss_bbox: 0.4150 (0.4730)  loss_giou: 0.7091 (0.7484)  loss_fgl: 1.1109 (1.1232)  loss_mal_aux_0: 1.1406 (1.1900)  loss_bbox_aux_0: 0.4522 (0.4865)  loss_giou_aux_0: 0.7479 (0.7674)  loss_fgl_aux_0: 1.1302 (1.1280)  loss_ddf_aux_0: 0.0254 (0.0274)  loss_mal_aux_1: 1.1074 (1.1850)  loss_bbox_aux_1: 0.4285 (0.4733)  loss_giou_aux_1: 0.7104 (0.7490)  loss_fgl_aux_1: 1.1139 (1.1235)  loss_ddf_aux_1: 0.0017 (0.0019)  loss_mal_pre: 1.1387 (1.1882)  loss_bbox_pre: 0.4568 (0.4861)  loss_giou_pre: 0.7429 (0.7660)  loss_mal_enc_0: 1.1523 (1.2117)  loss_bbox_enc_0: 0.5232 (0.5594)  loss_giou_enc_0: 0.8067 (0.8494)  loss_mal_dn_0: 0.7837 (0.7863)  loss_bbox_dn_0: 0.4453 (0.5478)  loss_giou_dn_0: 0.7641 (0.8538)  loss_fgl_dn_0: 1.1316 (1.1156)  loss_ddf_dn_0: 0.1077 (0.1085)  loss_mal_dn_1: 0.7832 (0.7867)  loss_bbox_dn_1: 0.3746 (0.4916)  loss_giou_dn_1: 0.6921 (0.7735)  loss_fgl_dn_1: 1.1261 (1.1188)  loss_ddf_dn_1: 0.0078 (0.0071)  loss_mal_dn_2: 0.7686 (0.7804)  loss_bbox_dn_2: 0.3820 (0.4876)  loss_giou_dn_2: 0.6834 (0.7677)  loss_fgl_dn_2: 1.1219 (1.1182)  loss_mal_dn_pre: 0.7832 (0.7857)  loss_bbox_dn_pre: 0.4410 (0.5478)  loss_giou_dn_pre: 0.7657 (0.8534)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 15.16it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.441\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.682\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.511\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.056\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.180\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.480\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.567\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.706\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.743\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.062\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.397\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.788\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.972\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.863\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:36:16.855\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:36:16.857\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 4 / mAP: 0.4408642088712889\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:36:16.858\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 4, 'coco_eval_bbox': 0.4408642088712889}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:36:16.859\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 5/10\u001b[0m\n",
+      "Epoch 5:   0%|          | 0/403 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     ### Attention --- Mixup is closed after epoch@ 5 ###\n",
+      "     ### Attention --- Mixup is closed after epoch@ 5 ###\n",
+      "     ### Attention --- Mixup is closed after epoch@ 5 ###\n",
+      "     ### Attention --- Mixup is closed after epoch@ 5 ###\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 5: 100%|██████████| 403/403 [01:34<00:00,  4.26it/s, loss=25.1632]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000185  loss: 25.4497 (26.7360)  loss_mal: 1.0576 (1.2046)  loss_bbox: 0.3853 (0.4362)  loss_giou: 0.4611 (0.5174)  loss_fgl: 1.1620 (1.1748)  loss_mal_aux_0: 1.1758 (1.2836)  loss_bbox_aux_0: 0.4259 (0.4794)  loss_giou_aux_0: 0.4994 (0.5538)  loss_fgl_aux_0: 1.1841 (1.1967)  loss_ddf_aux_0: 0.0411 (0.0428)  loss_mal_aux_1: 1.0869 (1.2554)  loss_bbox_aux_1: 0.3816 (0.4374)  loss_giou_aux_1: 0.4622 (0.5188)  loss_fgl_aux_1: 1.1616 (1.1755)  loss_ddf_aux_1: 0.0026 (0.0026)  loss_mal_pre: 1.1836 (1.2817)  loss_bbox_pre: 0.4174 (0.4770)  loss_giou_pre: 0.4996 (0.5516)  loss_mal_enc_0: 1.3203 (1.3467)  loss_bbox_enc_0: 0.5833 (0.6561)  loss_giou_enc_0: 0.6506 (0.6887)  loss_mal_dn_0: 0.7739 (0.7901)  loss_bbox_dn_0: 0.4992 (0.6141)  loss_giou_dn_0: 0.6362 (0.6686)  loss_fgl_dn_0: 1.1881 (1.1985)  loss_ddf_dn_0: 0.1653 (0.1508)  loss_mal_dn_1: 0.7324 (0.7567)  loss_bbox_dn_1: 0.3843 (0.4928)  loss_giou_dn_1: 0.5155 (0.5620)  loss_fgl_dn_1: 1.1660 (1.1786)  loss_ddf_dn_1: 0.0106 (0.0110)  loss_mal_dn_2: 0.7134 (0.7490)  loss_bbox_dn_2: 0.3808 (0.4818)  loss_giou_dn_2: 0.5061 (0.5524)  loss_fgl_dn_2: 1.1649 (1.1753)  loss_mal_dn_pre: 0.7734 (0.7896)  loss_bbox_dn_pre: 0.5000 (0.6163)  loss_giou_dn_pre: 0.6387 (0.6677)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 15.93it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.490\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.755\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.550\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.076\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.235\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.526\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.589\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.733\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.780\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.125\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.441\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.822\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.983\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.900\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:37:53.998\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:37:54.000\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 5 / mAP: 0.48955560652058994\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:37:54.001\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 5, 'coco_eval_bbox': 0.48955560652058994}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:37:54.001\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 6/10\u001b[0m\n",
+      "Epoch 6: 100%|██████████| 403/403 [01:33<00:00,  4.31it/s, loss=25.3044]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000150  loss: 23.8592 (25.4484)  loss_mal: 0.9897 (1.0967)  loss_bbox: 0.3351 (0.4055)  loss_giou: 0.4467 (0.5102)  loss_fgl: 1.1545 (1.1538)  loss_mal_aux_0: 1.1035 (1.1886)  loss_bbox_aux_0: 0.3805 (0.4452)  loss_giou_aux_0: 0.4609 (0.5432)  loss_fgl_aux_0: 1.1886 (1.1816)  loss_ddf_aux_0: 0.0351 (0.0419)  loss_mal_aux_1: 1.0107 (1.1406)  loss_bbox_aux_1: 0.3509 (0.4063)  loss_giou_aux_1: 0.4430 (0.5111)  loss_fgl_aux_1: 1.1574 (1.1553)  loss_ddf_aux_1: 0.0025 (0.0026)  loss_mal_pre: 1.0996 (1.1884)  loss_bbox_pre: 0.3749 (0.4435)  loss_giou_pre: 0.4583 (0.5413)  loss_mal_enc_0: 1.2275 (1.2639)  loss_bbox_enc_0: 0.5133 (0.5916)  loss_giou_enc_0: 0.6060 (0.6603)  loss_mal_dn_0: 0.7622 (0.7744)  loss_bbox_dn_0: 0.4946 (0.5582)  loss_giou_dn_0: 0.5666 (0.6286)  loss_fgl_dn_0: 1.2094 (1.2019)  loss_ddf_dn_0: 0.1486 (0.1596)  loss_mal_dn_1: 0.7012 (0.7243)  loss_bbox_dn_1: 0.3682 (0.4396)  loss_giou_dn_1: 0.4553 (0.5230)  loss_fgl_dn_1: 1.1690 (1.1697)  loss_ddf_dn_1: 0.0110 (0.0108)  loss_mal_dn_2: 0.6797 (0.7154)  loss_bbox_dn_2: 0.3551 (0.4297)  loss_giou_dn_2: 0.4368 (0.5148)  loss_fgl_dn_2: 1.1558 (1.1650)  loss_mal_dn_pre: 0.7627 (0.7739)  loss_bbox_dn_pre: 0.5012 (0.5608)  loss_giou_dn_pre: 0.5700 (0.6274)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 14.96it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.564\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.828\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.658\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.120\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.288\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.602\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.631\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.748\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.789\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.125\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.466\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.829\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.975\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.907\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:39:30.307\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:39:30.308\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 6 / mAP: 0.5643534456201034\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:39:30.310\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 6, 'coco_eval_bbox': 0.5643534456201034}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:39:30.310\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 7/10\u001b[0m\n",
+      "Epoch 7: 100%|██████████| 403/403 [01:35<00:00,  4.23it/s, loss=23.7916]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000115  loss: 23.1560 (24.0638)  loss_mal: 0.8701 (0.9728)  loss_bbox: 0.3136 (0.3812)  loss_giou: 0.4616 (0.4784)  loss_fgl: 1.1035 (1.1471)  loss_mal_aux_0: 0.9316 (1.0702)  loss_bbox_aux_0: 0.3222 (0.4175)  loss_giou_aux_0: 0.4585 (0.5100)  loss_fgl_aux_0: 1.1484 (1.1776)  loss_ddf_aux_0: 0.0341 (0.0428)  loss_mal_aux_1: 0.9097 (1.0105)  loss_bbox_aux_1: 0.3126 (0.3827)  loss_giou_aux_1: 0.4573 (0.4795)  loss_fgl_aux_1: 1.1039 (1.1483)  loss_ddf_aux_1: 0.0022 (0.0027)  loss_mal_pre: 0.9487 (1.0684)  loss_bbox_pre: 0.3228 (0.4159)  loss_giou_pre: 0.4619 (0.5087)  loss_mal_enc_0: 1.0986 (1.1786)  loss_bbox_enc_0: 0.4347 (0.5492)  loss_giou_enc_0: 0.5728 (0.6234)  loss_mal_dn_0: 0.7339 (0.7565)  loss_bbox_dn_0: 0.4538 (0.5068)  loss_giou_dn_0: 0.5444 (0.5812)  loss_fgl_dn_0: 1.1968 (1.2068)  loss_ddf_dn_0: 0.1559 (0.1664)  loss_mal_dn_1: 0.6582 (0.6904)  loss_bbox_dn_1: 0.3471 (0.3969)  loss_giou_dn_1: 0.4602 (0.4791)  loss_fgl_dn_1: 1.1312 (1.1603)  loss_ddf_dn_1: 0.0089 (0.0103)  loss_mal_dn_2: 0.6426 (0.6783)  loss_bbox_dn_2: 0.3183 (0.3889)  loss_giou_dn_2: 0.4631 (0.4725)  loss_fgl_dn_2: 1.1286 (1.1555)  loss_mal_dn_pre: 0.7334 (0.7559)  loss_bbox_dn_pre: 0.4622 (0.5119)  loss_giou_dn_pre: 0.5499 (0.5809)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 15.09it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.09s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.607\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.854\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.709\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.129\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.286\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.647\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.658\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.764\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.810\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.163\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.493\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.849\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.978\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.919\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:41:08.527\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:41:08.529\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 7 / mAP: 0.6068263126003467\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:41:08.530\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 7, 'coco_eval_bbox': 0.6068263126003467}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:41:08.531\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 8/10\u001b[0m\n",
+      "Epoch 8: 100%|██████████| 403/403 [01:37<00:00,  4.15it/s, loss=20.7844]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 21.3156 (23.3295)  loss_mal: 0.8184 (0.9265)  loss_bbox: 0.2955 (0.3659)  loss_giou: 0.3799 (0.4703)  loss_fgl: 1.1197 (1.1353)  loss_mal_aux_0: 0.9194 (1.0258)  loss_bbox_aux_0: 0.3195 (0.3958)  loss_giou_aux_0: 0.4110 (0.4977)  loss_fgl_aux_0: 1.1600 (1.1666)  loss_ddf_aux_0: 0.0316 (0.0415)  loss_mal_aux_1: 0.8545 (0.9649)  loss_bbox_aux_1: 0.2997 (0.3674)  loss_giou_aux_1: 0.3757 (0.4713)  loss_fgl_aux_1: 1.1341 (1.1368)  loss_ddf_aux_1: 0.0023 (0.0027)  loss_mal_pre: 0.9189 (1.0253)  loss_bbox_pre: 0.3081 (0.3941)  loss_giou_pre: 0.4056 (0.4966)  loss_mal_enc_0: 1.0459 (1.1337)  loss_bbox_enc_0: 0.4144 (0.5063)  loss_giou_enc_0: 0.5060 (0.6029)  loss_mal_dn_0: 0.7222 (0.7464)  loss_bbox_dn_0: 0.4209 (0.4689)  loss_giou_dn_0: 0.4621 (0.5591)  loss_fgl_dn_0: 1.2017 (1.2043)  loss_ddf_dn_0: 0.1442 (0.1620)  loss_mal_dn_1: 0.6353 (0.6734)  loss_bbox_dn_1: 0.2967 (0.3662)  loss_giou_dn_1: 0.3650 (0.4610)  loss_fgl_dn_1: 1.1250 (1.1493)  loss_ddf_dn_1: 0.0083 (0.0095)  loss_mal_dn_2: 0.6333 (0.6630)  loss_bbox_dn_2: 0.2834 (0.3588)  loss_giou_dn_2: 0.3631 (0.4552)  loss_fgl_dn_2: 1.1194 (1.1441)  loss_mal_dn_pre: 0.7217 (0.7458)  loss_bbox_dn_pre: 0.4286 (0.4756)  loss_giou_dn_pre: 0.4630 (0.5596)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 15.99it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.623\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.868\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.754\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.139\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.347\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.659\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.677\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.770\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.810\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.200\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.536\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.844\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.986\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.924\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:42:48.300\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:42:48.301\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 8 / mAP: 0.6230811541917246\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:42:48.302\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 8, 'coco_eval_bbox': 0.6230811541917246}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:42:48.303\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 9/10\u001b[0m\n",
+      "Epoch 9: 100%|██████████| 403/403 [01:16<00:00,  5.26it/s, loss=17.5473]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 18.2332 (19.4897)  loss_mal: 0.6187 (0.6835)  loss_bbox: 0.2478 (0.2810)  loss_giou: 0.2734 (0.3082)  loss_fgl: 1.0847 (1.1196)  loss_mal_aux_0: 0.7104 (0.8059)  loss_bbox_aux_0: 0.2820 (0.3069)  loss_giou_aux_0: 0.3012 (0.3332)  loss_fgl_aux_0: 1.1303 (1.1578)  loss_ddf_aux_0: 0.0432 (0.0454)  loss_mal_aux_1: 0.6553 (0.7166)  loss_bbox_aux_1: 0.2509 (0.2821)  loss_giou_aux_1: 0.2752 (0.3092)  loss_fgl_aux_1: 1.0858 (1.1208)  loss_ddf_aux_1: 0.0023 (0.0029)  loss_mal_pre: 0.7119 (0.8047)  loss_bbox_pre: 0.2818 (0.3045)  loss_giou_pre: 0.3033 (0.3315)  loss_mal_enc_0: 0.8496 (0.9305)  loss_bbox_enc_0: 0.3613 (0.3864)  loss_giou_enc_0: 0.3859 (0.4127)  loss_mal_dn_0: 0.6484 (0.6778)  loss_bbox_dn_0: 0.3506 (0.3806)  loss_giou_dn_0: 0.3544 (0.3991)  loss_fgl_dn_0: 1.1892 (1.2117)  loss_ddf_dn_0: 0.1932 (0.1803)  loss_mal_dn_1: 0.5269 (0.5678)  loss_bbox_dn_1: 0.2541 (0.2854)  loss_giou_dn_1: 0.2608 (0.3075)  loss_fgl_dn_1: 1.0826 (1.1182)  loss_ddf_dn_1: 0.0093 (0.0094)  loss_mal_dn_2: 0.5122 (0.5531)  loss_bbox_dn_2: 0.2476 (0.2795)  loss_giou_dn_2: 0.2612 (0.3025)  loss_fgl_dn_2: 1.0787 (1.1113)  loss_mal_dn_pre: 0.6484 (0.6765)  loss_bbox_dn_pre: 0.3526 (0.3863)  loss_giou_dn_pre: 0.3524 (0.3993)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 14.97it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.668\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.892\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.786\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.094\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.413\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.704\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.694\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.782\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.807\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.150\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.533\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.840\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.983\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.916\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:44:07.688\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:44:07.690\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 9 / mAP: 0.6683985051343009\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:44:07.691\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 9, 'coco_eval_bbox': 0.6683985051343009}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:44:07.691\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m555\u001b[0m - \u001b[1mTraining completed in 0:15:24\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:44:07.692\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m556\u001b[0m - \u001b[1mBest stats: {'epoch': 9, 'coco_eval_bbox': 0.6683985051343009}\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "from deimkit import Config, Trainer, configure_dataset, configure_model\n",
+    "\n",
+    "conf = Config.from_model_name(\"deim_hgnetv2_s\")\n",
+    "\n",
+    "conf = configure_model(conf, num_queries=100, freeze_at=0, pretrained=True)\n",
+    "\n",
+    "conf = configure_dataset(\n",
+    "    config=conf,\n",
+    "    image_size=(128, 128),\n",
+    "    train_ann_file=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train/_annotations.coco.json\",\n",
+    "    train_img_folder=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train\",\n",
+    "    val_ann_file=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid/_annotations.coco.json\",\n",
+    "    val_img_folder=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid\",\n",
+    "    train_batch_size=16,\n",
+    "    val_batch_size=16,\n",
+    "    num_classes=4,\n",
+    "    output_dir=\"./outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px\",\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(conf)\n",
+    "\n",
+    "trainer.fit(epochs=10, save_best_only=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train at 320px for 10 epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:45:42.230\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.DFINETransformer.num_queries' to: 100\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.230\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.PostProcessor.num_top_queries' to: 100\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.231\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.HGNetv2.pretrained' to: True\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.231\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.HGNetv2.freeze_at' to: 0\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.232\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_init_process_group\u001b[0m:\u001b[36m60\u001b[0m - \u001b[1mInitializing process group for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.249\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_checkpoint\u001b[0m:\u001b[36m624\u001b[0m - \u001b[1mLoading checkpoint from outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.473\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m152\u001b[0m - \u001b[1mDisabling sync_bn and find_unused_parameters for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.474\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m164\u001b[0m - \u001b[1mSet device in config: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.474\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m174\u001b[0m - \u001b[1mInitializing solver for task: detection\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded stage1 B0 HGNetV2 from local file.\n",
+      "Initial lr: [0.0002, 0.0004, 0.0004]\n",
+      "building train_dataloader with batch_size=16...\n",
+      "     ### Transform @Mosaic ###    \n",
+      "     ### Transform @RandomPhotometricDistort ###    \n",
+      "     ### Transform @RandomZoomOut ###    \n",
+      "     ### Transform @RandomIoUCrop ###    \n",
+      "     ### Transform @SanitizeBoundingBoxes ###    \n",
+      "     ### Transform @RandomHorizontalFlip ###    \n",
+      "     ### Transform @Resize ###    \n",
+      "     ### Transform @SanitizeBoundingBoxes ###    \n",
+      "     ### Transform @ConvertPILImage ###    \n",
+      "     ### Transform @ConvertBoxes ###    \n",
+      "     ### Mosaic with Prob.@0.5 and ZoomOut/IoUCrop existed ### \n",
+      "     ### ImgTransforms Epochs: [4, 64, 120] ### \n",
+      "     ### Policy_ops@['Mosaic', 'RandomPhotometricDistort', 'RandomZoomOut', 'RandomIoUCrop'] ###\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:45:42.726\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m201\u001b[0m - \u001b[1mTraining setup complete. Output directory: outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.727\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m203\u001b[0m - \u001b[1mSaving config to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/config.yml\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.764\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m642\u001b[0m - \u001b[33m\u001b[1mShape mismatch, loading compatible parameters only: Error(s) in loading state_dict for DistributedDataParallel:\n",
+      "\tsize mismatch for module.decoder.anchors: copying a param with shape torch.Size([1, 336, 4]) from checkpoint, the shape in current model is torch.Size([1, 2100, 4]).\n",
+      "\tsize mismatch for module.decoder.valid_mask: copying a param with shape torch.Size([1, 336, 1]) from checkpoint, the shape in current model is torch.Size([1, 2100, 1]).\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.795\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m649\u001b[0m - \u001b[1mLoaded parameters with matching shapes\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.820\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_checkpoint\u001b[0m:\u001b[36m659\u001b[0m - \u001b[1mAttempting to load EMA parameters with matching shapes...\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.848\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m642\u001b[0m - \u001b[33m\u001b[1mShape mismatch, loading compatible parameters only: Error(s) in loading state_dict for DEIM:\n",
+      "\tsize mismatch for decoder.anchors: copying a param with shape torch.Size([1, 336, 4]) from checkpoint, the shape in current model is torch.Size([1, 2100, 4]).\n",
+      "\tsize mismatch for decoder.valid_mask: copying a param with shape torch.Size([1, 336, 1]) from checkpoint, the shape in current model is torch.Size([1, 2100, 1]).\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:42.880\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m649\u001b[0m - \u001b[1mLoaded parameters with matching shapes\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     ### Using MixUp with Prob@0.5 in [4, 64] epochs ### \n",
+      "     ### Multi-scale Training until 120 epochs ### \n",
+      "     ### Multi-scales@ [224, 256, 288, 320, 320, 320, 320, 320, 320, 320, 320, 320, 320, 320, 320, 320, 320, 320, 320, 320, 320, 320, 320, 384, 352, 320] ###        \n",
+      "building val_dataloader with batch_size=16...\n",
+      "     ### Transform @Resize ###    \n",
+      "     ### Transform @ConvertPILImage ###    \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:45:43.046\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_checkpoint\u001b[0m:\u001b[36m671\u001b[0m - \u001b[1mLoaded checkpoint from epoch 9\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.052\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m239\u001b[0m - \u001b[1mStarting training...\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.052\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m242\u001b[0m - \u001b[1mOverriding epochs to 10\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.052\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m276\u001b[0m - \u001b[1mSetting pretrained flag to True for HGNetv2\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.053\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m296\u001b[0m - \u001b[1mAutomatically calculated mixup epochs: [1, 5]\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.053\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m306\u001b[0m - \u001b[1mAutomatically calculated data augmentation epochs: 1, 5, 9\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.053\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m315\u001b[0m - \u001b[1mAutomatically calculated stop epoch: 9\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.053\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m323\u001b[0m - \u001b[1mAutomatically calculated no augmentation epochs: 1\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.054\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m336\u001b[0m - \u001b[1mAutomatically calculated flat epochs: 5\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.057\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m363\u001b[0m - \u001b[1mAutomatically calculated warmup iterations: 403 (1.0 epochs)\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.058\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m376\u001b[0m - \u001b[1mAutomatically calculated EMA warmups: 403 (1.0 epochs)\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.058\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m152\u001b[0m - \u001b[1mDisabling sync_bn and find_unused_parameters for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.058\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m164\u001b[0m - \u001b[1mSet device in config: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.059\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m174\u001b[0m - \u001b[1mInitializing solver for task: detection\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.095\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m201\u001b[0m - \u001b[1mTraining setup complete. Output directory: outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.096\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m203\u001b[0m - \u001b[1mSaving config to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/config.yml\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.102\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m384\u001b[0m - \u001b[1mUsing device: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.340\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.341\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m393\u001b[0m - \u001b[1mInitial model saved as best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.343\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m403\u001b[0m - \u001b[1mNumber of trainable parameters: 10217817\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.344\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m409\u001b[0m - \u001b[1mUsing custom scheduler: flatcosine\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:45:43.344\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 0/10\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.0002, 0.0004, 0.0004] [0.0001, 0.0002, 0.0002] 4030 403 2015 403\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 403/403 [01:24<00:00,  4.78it/s, loss=20.4246]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000199  loss: 20.9291 (25.6709)  loss_mal: 0.7881 (1.0648)  loss_bbox: 0.2890 (0.4148)  loss_giou: 0.2993 (0.3665)  loss_fgl: 1.1075 (1.1399)  loss_mal_aux_0: 1.0205 (1.3155)  loss_bbox_aux_0: 0.3500 (0.4799)  loss_giou_aux_0: 0.3468 (0.4348)  loss_fgl_aux_0: 1.1882 (1.2007)  loss_ddf_aux_0: 0.0817 (0.1295)  loss_mal_aux_1: 0.8838 (1.1244)  loss_bbox_aux_1: 0.3018 (0.4194)  loss_giou_aux_1: 0.2953 (0.3733)  loss_fgl_aux_1: 1.1101 (1.1445)  loss_ddf_aux_1: 0.0042 (0.0075)  loss_mal_pre: 1.0186 (1.3062)  loss_bbox_pre: 0.3485 (0.4812)  loss_giou_pre: 0.3429 (0.4357)  loss_mal_enc_0: 1.0977 (1.4812)  loss_bbox_enc_0: 0.5121 (0.8715)  loss_giou_enc_0: 0.4468 (0.6804)  loss_mal_dn_0: 0.7212 (0.7482)  loss_bbox_dn_0: 0.4736 (0.6060)  loss_giou_dn_0: 0.4313 (0.5724)  loss_fgl_dn_0: 1.2407 (1.3240)  loss_ddf_dn_0: 0.2512 (0.3457)  loss_mal_dn_1: 0.5952 (0.6414)  loss_bbox_dn_1: 0.3249 (0.4317)  loss_giou_dn_1: 0.2992 (0.4076)  loss_fgl_dn_1: 1.1106 (1.1967)  loss_ddf_dn_1: 0.0177 (0.0321)  loss_mal_dn_2: 0.5747 (0.6289)  loss_bbox_dn_2: 0.3155 (0.4002)  loss_giou_dn_2: 0.2843 (0.3789)  loss_fgl_dn_2: 1.0981 (1.1662)  loss_mal_dn_pre: 0.7227 (0.7505)  loss_bbox_dn_pre: 0.4806 (0.6040)  loss_giou_dn_pre: 0.4355 (0.5649)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 13.23it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.594\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.820\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.701\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.262\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.372\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.625\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.683\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.808\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.849\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.275\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.622\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.875\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.950\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:47:10.772\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:47:10.774\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 0 / mAP: 0.5939395608050839\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:47:10.776\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 0, 'coco_eval_bbox': 0.5939395608050839}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:47:10.776\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 1/10\u001b[0m\n",
+      "Epoch 1: 100%|██████████| 403/403 [01:25<00:00,  4.69it/s, loss=19.4599]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 19.2453 (20.8732)  loss_mal: 0.6538 (0.7998)  loss_bbox: 0.2204 (0.2798)  loss_giou: 0.2386 (0.2821)  loss_fgl: 1.0168 (1.1039)  loss_mal_aux_0: 0.8066 (0.9483)  loss_bbox_aux_0: 0.3043 (0.3349)  loss_giou_aux_0: 0.3043 (0.3346)  loss_fgl_aux_0: 1.1468 (1.1787)  loss_ddf_aux_0: 0.1287 (0.1094)  loss_mal_aux_1: 0.7095 (0.8371)  loss_bbox_aux_1: 0.2270 (0.2829)  loss_giou_aux_1: 0.2412 (0.2850)  loss_fgl_aux_1: 1.0240 (1.1070)  loss_ddf_aux_1: 0.0061 (0.0067)  loss_mal_pre: 0.8057 (0.9451)  loss_bbox_pre: 0.2960 (0.3291)  loss_giou_pre: 0.2966 (0.3311)  loss_mal_enc_0: 0.9556 (1.0765)  loss_bbox_enc_0: 0.5139 (0.5126)  loss_giou_enc_0: 0.4521 (0.4843)  loss_mal_dn_0: 0.6763 (0.7071)  loss_bbox_dn_0: 0.4002 (0.4388)  loss_giou_dn_0: 0.3942 (0.4362)  loss_fgl_dn_0: 1.2208 (1.2391)  loss_ddf_dn_0: 0.3377 (0.3105)  loss_mal_dn_1: 0.5439 (0.5889)  loss_bbox_dn_1: 0.2618 (0.3029)  loss_giou_dn_1: 0.2566 (0.3013)  loss_fgl_dn_1: 1.0630 (1.1154)  loss_ddf_dn_1: 0.0194 (0.0214)  loss_mal_dn_2: 0.5249 (0.5729)  loss_bbox_dn_2: 0.2385 (0.2900)  loss_giou_dn_2: 0.2491 (0.2896)  loss_fgl_dn_2: 1.0422 (1.1036)  loss_mal_dn_pre: 0.6768 (0.7058)  loss_bbox_dn_pre: 0.4197 (0.4452)  loss_giou_dn_pre: 0.3931 (0.4356)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 13.58it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.664\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.867\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.789\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.317\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.442\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.695\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.716\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.824\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.855\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.685\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.879\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.986\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.960\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:48:39.848\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:48:39.850\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 1 / mAP: 0.6638475991291312\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:48:39.850\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 1, 'coco_eval_bbox': 0.6638475991291312}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:48:39.851\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 2/10\u001b[0m\n",
+      "Epoch 2: 100%|██████████| 403/403 [01:24<00:00,  4.76it/s, loss=16.1202]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 17.2533 (18.9859)  loss_mal: 0.5601 (0.6687)  loss_bbox: 0.2021 (0.2366)  loss_giou: 0.2049 (0.2477)  loss_fgl: 1.0068 (1.0672)  loss_mal_aux_0: 0.7593 (0.8286)  loss_bbox_aux_0: 0.2509 (0.2821)  loss_giou_aux_0: 0.2509 (0.2931)  loss_fgl_aux_0: 1.1130 (1.1472)  loss_ddf_aux_0: 0.1230 (0.1078)  loss_mal_aux_1: 0.6323 (0.7087)  loss_bbox_aux_1: 0.1986 (0.2392)  loss_giou_aux_1: 0.2051 (0.2499)  loss_fgl_aux_1: 1.0030 (1.0705)  loss_ddf_aux_1: 0.0052 (0.0063)  loss_mal_pre: 0.7578 (0.8262)  loss_bbox_pre: 0.2473 (0.2776)  loss_giou_pre: 0.2501 (0.2904)  loss_mal_enc_0: 0.9019 (0.9303)  loss_bbox_enc_0: 0.3827 (0.4329)  loss_giou_enc_0: 0.3895 (0.4270)  loss_mal_dn_0: 0.6353 (0.6688)  loss_bbox_dn_0: 0.3335 (0.3771)  loss_giou_dn_0: 0.3441 (0.3849)  loss_fgl_dn_0: 1.1956 (1.2255)  loss_ddf_dn_0: 0.3670 (0.3364)  loss_mal_dn_1: 0.4844 (0.5347)  loss_bbox_dn_1: 0.2030 (0.2530)  loss_giou_dn_1: 0.2136 (0.2605)  loss_fgl_dn_1: 1.0117 (1.0764)  loss_ddf_dn_1: 0.0178 (0.0207)  loss_mal_dn_2: 0.4646 (0.5192)  loss_bbox_dn_2: 0.1941 (0.2416)  loss_giou_dn_2: 0.2086 (0.2508)  loss_fgl_dn_2: 0.9977 (1.0634)  loss_mal_dn_pre: 0.6343 (0.6676)  loss_bbox_dn_pre: 0.3402 (0.3832)  loss_giou_dn_pre: 0.3433 (0.3844)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 13.06it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.692\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.915\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.824\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.243\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.466\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.718\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.708\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.820\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.849\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.300\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.714\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.871\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.960\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:50:07.797\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:50:07.800\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 2 / mAP: 0.6915307937565691\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:50:07.801\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 2, 'coco_eval_bbox': 0.6915307937565691}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:50:07.801\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 3/10\u001b[0m\n",
+      "Epoch 3: 100%|██████████| 403/403 [01:23<00:00,  4.80it/s, loss=15.9807]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 17.2851 (18.0803)  loss_mal: 0.4890 (0.6031)  loss_bbox: 0.1914 (0.2149)  loss_giou: 0.2028 (0.2301)  loss_fgl: 0.9794 (1.0378)  loss_mal_aux_0: 0.6562 (0.7648)  loss_bbox_aux_0: 0.2431 (0.2600)  loss_giou_aux_0: 0.2571 (0.2765)  loss_fgl_aux_0: 1.0899 (1.1313)  loss_ddf_aux_0: 0.1015 (0.1181)  loss_mal_aux_1: 0.5410 (0.6427)  loss_bbox_aux_1: 0.1961 (0.2170)  loss_giou_aux_1: 0.2081 (0.2323)  loss_fgl_aux_1: 0.9878 (1.0425)  loss_ddf_aux_1: 0.0044 (0.0067)  loss_mal_pre: 0.6558 (0.7637)  loss_bbox_pre: 0.2427 (0.2565)  loss_giou_pre: 0.2514 (0.2732)  loss_mal_enc_0: 0.8501 (0.8838)  loss_bbox_enc_0: 0.3784 (0.4162)  loss_giou_enc_0: 0.3778 (0.4093)  loss_mal_dn_0: 0.6138 (0.6470)  loss_bbox_dn_0: 0.3309 (0.3460)  loss_giou_dn_0: 0.3379 (0.3626)  loss_fgl_dn_0: 1.1830 (1.2163)  loss_ddf_dn_0: 0.3377 (0.3616)  loss_mal_dn_1: 0.4731 (0.5071)  loss_bbox_dn_1: 0.2178 (0.2248)  loss_giou_dn_1: 0.2204 (0.2398)  loss_fgl_dn_1: 1.0031 (1.0444)  loss_ddf_dn_1: 0.0146 (0.0204)  loss_mal_dn_2: 0.4480 (0.4907)  loss_bbox_dn_2: 0.2043 (0.2149)  loss_giou_dn_2: 0.2060 (0.2313)  loss_fgl_dn_2: 0.9833 (1.0315)  loss_mal_dn_pre: 0.6113 (0.6458)  loss_bbox_dn_pre: 0.3398 (0.3527)  loss_giou_dn_pre: 0.3390 (0.3626)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 12.35it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.08s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.706\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.910\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.834\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.283\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.499\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.733\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.730\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.839\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.856\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.673\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.878\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.951\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:51:35.196\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:51:35.198\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 3 / mAP: 0.7060293766469423\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:51:35.199\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 3, 'coco_eval_bbox': 0.7060293766469423}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:51:35.200\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 4/10\u001b[0m\n",
+      "Epoch 4: 100%|██████████| 403/403 [01:49<00:00,  3.69it/s, loss=27.1769]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 21.2946 (24.4727)  loss_mal: 0.9131 (1.0443)  loss_bbox: 0.2617 (0.3758)  loss_giou: 0.4328 (0.5625)  loss_fgl: 1.1156 (1.1392)  loss_mal_aux_0: 1.0381 (1.0808)  loss_bbox_aux_0: 0.2748 (0.3927)  loss_giou_aux_0: 0.4783 (0.5942)  loss_fgl_aux_0: 1.1623 (1.1621)  loss_ddf_aux_0: 0.0557 (0.0653)  loss_mal_aux_1: 0.9678 (1.0544)  loss_bbox_aux_1: 0.2595 (0.3764)  loss_giou_aux_1: 0.4347 (0.5636)  loss_fgl_aux_1: 1.1167 (1.1398)  loss_ddf_aux_1: 0.0035 (0.0037)  loss_mal_pre: 1.0391 (1.0792)  loss_bbox_pre: 0.2692 (0.3915)  loss_giou_pre: 0.4764 (0.5935)  loss_mal_enc_0: 1.0840 (1.1173)  loss_bbox_enc_0: 0.4143 (0.4661)  loss_giou_enc_0: 0.5798 (0.6978)  loss_mal_dn_0: 0.7432 (0.7605)  loss_bbox_dn_0: 0.3364 (0.4208)  loss_giou_dn_0: 0.5183 (0.6405)  loss_fgl_dn_0: 1.1944 (1.1884)  loss_ddf_dn_0: 0.2129 (0.2303)  loss_mal_dn_1: 0.6655 (0.7146)  loss_bbox_dn_1: 0.2541 (0.3655)  loss_giou_dn_1: 0.3985 (0.5354)  loss_fgl_dn_1: 1.1243 (1.1411)  loss_ddf_dn_1: 0.0111 (0.0127)  loss_mal_dn_2: 0.6572 (0.7090)  loss_bbox_dn_2: 0.2423 (0.3621)  loss_giou_dn_2: 0.3847 (0.5287)  loss_fgl_dn_2: 1.1234 (1.1393)  loss_mal_dn_pre: 0.7441 (0.7604)  loss_bbox_dn_pre: 0.3326 (0.4215)  loss_giou_dn_pre: 0.5272 (0.6415)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 12.20it/s]\n",
+      "\u001b[32m2025-04-03 14:53:27.586\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 3, 'coco_eval_bbox': 0.7060293766469423}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:53:27.586\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 5/10\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.690\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.912\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.821\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.303\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.395\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.720\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.711\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.808\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.841\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.312\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.653\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.866\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.956\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 5: 100%|██████████| 403/403 [01:49<00:00,  3.67it/s, loss=25.7934]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000185  loss: 24.9913 (23.3430)  loss_mal: 1.0430 (0.9657)  loss_bbox: 0.4042 (0.3391)  loss_giou: 0.5768 (0.5167)  loss_fgl: 1.1263 (1.1294)  loss_mal_aux_0: 1.0674 (1.0272)  loss_bbox_aux_0: 0.4079 (0.3557)  loss_giou_aux_0: 0.6089 (0.5467)  loss_fgl_aux_0: 1.1505 (1.1572)  loss_ddf_aux_0: 0.0563 (0.0641)  loss_mal_aux_1: 1.0635 (0.9822)  loss_bbox_aux_1: 0.4073 (0.3399)  loss_giou_aux_1: 0.5789 (0.5180)  loss_fgl_aux_1: 1.1240 (1.1301)  loss_ddf_aux_1: 0.0034 (0.0034)  loss_mal_pre: 1.0615 (1.0259)  loss_bbox_pre: 0.4074 (0.3547)  loss_giou_pre: 0.6037 (0.5458)  loss_mal_enc_0: 1.1162 (1.0865)  loss_bbox_enc_0: 0.4680 (0.4386)  loss_giou_enc_0: 0.6962 (0.6643)  loss_mal_dn_0: 0.7529 (0.7471)  loss_bbox_dn_0: 0.4443 (0.3873)  loss_giou_dn_0: 0.6495 (0.5959)  loss_fgl_dn_0: 1.1773 (1.1941)  loss_ddf_dn_0: 0.2383 (0.2181)  loss_mal_dn_1: 0.7168 (0.6887)  loss_bbox_dn_1: 0.3908 (0.3318)  loss_giou_dn_1: 0.5368 (0.4916)  loss_fgl_dn_1: 1.1223 (1.1318)  loss_ddf_dn_1: 0.0113 (0.0106)  loss_mal_dn_2: 0.7119 (0.6802)  loss_bbox_dn_2: 0.3841 (0.3283)  loss_giou_dn_2: 0.5271 (0.4855)  loss_fgl_dn_2: 1.1196 (1.1292)  loss_mal_dn_pre: 0.7549 (0.7467)  loss_bbox_dn_pre: 0.4432 (0.3883)  loss_giou_dn_pre: 0.6493 (0.5966)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:03<00:00, 11.40it/s]\n",
+      "\u001b[32m2025-04-03 14:55:20.563\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 3, 'coco_eval_bbox': 0.7060293766469423}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:55:20.563\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 6/10\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.692\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.907\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.833\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.325\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.394\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.722\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.720\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.811\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.840\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.676\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.862\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.951\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 6: 100%|██████████| 403/403 [01:47<00:00,  3.75it/s, loss=18.2418]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000150  loss: 21.7340 (22.8158)  loss_mal: 0.9360 (0.9444)  loss_bbox: 0.3274 (0.3230)  loss_giou: 0.4614 (0.5012)  loss_fgl: 1.1312 (1.1244)  loss_mal_aux_0: 1.0107 (1.0059)  loss_bbox_aux_0: 0.3195 (0.3375)  loss_giou_aux_0: 0.4762 (0.5281)  loss_fgl_aux_0: 1.1475 (1.1547)  loss_ddf_aux_0: 0.0506 (0.0594)  loss_mal_aux_1: 0.9614 (0.9574)  loss_bbox_aux_1: 0.3265 (0.3238)  loss_giou_aux_1: 0.4643 (0.5024)  loss_fgl_aux_1: 1.1311 (1.1256)  loss_ddf_aux_1: 0.0027 (0.0029)  loss_mal_pre: 1.0078 (1.0045)  loss_bbox_pre: 0.3152 (0.3365)  loss_giou_pre: 0.4781 (0.5272)  loss_mal_enc_0: 1.0127 (1.0662)  loss_bbox_enc_0: 0.3481 (0.4073)  loss_giou_enc_0: 0.5390 (0.6311)  loss_mal_dn_0: 0.7422 (0.7392)  loss_bbox_dn_0: 0.3563 (0.3711)  loss_giou_dn_0: 0.5366 (0.5775)  loss_fgl_dn_0: 1.1872 (1.1903)  loss_ddf_dn_0: 0.1917 (0.2052)  loss_mal_dn_1: 0.6655 (0.6753)  loss_bbox_dn_1: 0.3086 (0.3183)  loss_giou_dn_1: 0.4674 (0.4790)  loss_fgl_dn_1: 1.1089 (1.1229)  loss_ddf_dn_1: 0.0078 (0.0088)  loss_mal_dn_2: 0.6509 (0.6679)  loss_bbox_dn_2: 0.2975 (0.3151)  loss_giou_dn_2: 0.4618 (0.4733)  loss_fgl_dn_2: 1.1095 (1.1199)  loss_mal_dn_pre: 0.7402 (0.7385)  loss_bbox_dn_pre: 0.3585 (0.3724)  loss_giou_dn_pre: 0.5374 (0.5779)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 13.46it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.707\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.917\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.833\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.336\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.455\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.734\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.731\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.816\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.842\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.679\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.866\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.961\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:57:11.048\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:57:11.049\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 6 / mAP: 0.7073241366390274\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:57:11.051\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 6, 'coco_eval_bbox': 0.7073241366390274}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:57:11.051\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 7/10\u001b[0m\n",
+      "Epoch 7: 100%|██████████| 403/403 [01:45<00:00,  3.82it/s, loss=24.5654]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000115  loss: 21.1573 (21.8979)  loss_mal: 0.8228 (0.8896)  loss_bbox: 0.2414 (0.2937)  loss_giou: 0.4406 (0.4678)  loss_fgl: 1.1064 (1.1179)  loss_mal_aux_0: 0.9023 (0.9569)  loss_bbox_aux_0: 0.2541 (0.3079)  loss_giou_aux_0: 0.4636 (0.4945)  loss_fgl_aux_0: 1.1419 (1.1500)  loss_ddf_aux_0: 0.0545 (0.0626)  loss_mal_aux_1: 0.8438 (0.9063)  loss_bbox_aux_1: 0.2422 (0.2945)  loss_giou_aux_1: 0.4395 (0.4691)  loss_fgl_aux_1: 1.1078 (1.1189)  loss_ddf_aux_1: 0.0027 (0.0030)  loss_mal_pre: 0.9028 (0.9553)  loss_bbox_pre: 0.2545 (0.3073)  loss_giou_pre: 0.4648 (0.4935)  loss_mal_enc_0: 0.9858 (1.0289)  loss_bbox_enc_0: 0.3233 (0.3775)  loss_giou_enc_0: 0.5969 (0.6013)  loss_mal_dn_0: 0.7319 (0.7249)  loss_bbox_dn_0: 0.2693 (0.3430)  loss_giou_dn_0: 0.5035 (0.5389)  loss_fgl_dn_0: 1.1855 (1.1905)  loss_ddf_dn_0: 0.1927 (0.2055)  loss_mal_dn_1: 0.6426 (0.6508)  loss_bbox_dn_1: 0.2394 (0.2911)  loss_giou_dn_1: 0.4066 (0.4445)  loss_fgl_dn_1: 1.1165 (1.1149)  loss_ddf_dn_1: 0.0075 (0.0081)  loss_mal_dn_2: 0.6387 (0.6418)  loss_bbox_dn_2: 0.2417 (0.2880)  loss_giou_dn_2: 0.4067 (0.4393)  loss_fgl_dn_2: 1.1137 (1.1118)  loss_mal_dn_pre: 0.7319 (0.7242)  loss_bbox_dn_pre: 0.2704 (0.3446)  loss_giou_dn_pre: 0.5070 (0.5394)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:02<00:00, 12.73it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.715\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.925\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.846\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.332\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.440\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.744\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.729\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.812\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.843\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.665\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.868\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.954\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 14:58:59.830\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:58:59.832\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 7 / mAP: 0.7152077337912324\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:58:59.833\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 7, 'coco_eval_bbox': 0.7152077337912324}\u001b[0m\n",
+      "\u001b[32m2025-04-03 14:58:59.834\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 8/10\u001b[0m\n",
+      "Epoch 8: 100%|██████████| 403/403 [01:48<00:00,  3.72it/s, loss=17.4815]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 20.4672 (21.5759)  loss_mal: 0.7183 (0.8693)  loss_bbox: 0.2861 (0.2891)  loss_giou: 0.4287 (0.4604)  loss_fgl: 1.1047 (1.1067)  loss_mal_aux_0: 0.9185 (0.9414)  loss_bbox_aux_0: 0.2928 (0.3033)  loss_giou_aux_0: 0.4560 (0.4854)  loss_fgl_aux_0: 1.1484 (1.1407)  loss_ddf_aux_0: 0.0654 (0.0656)  loss_mal_aux_1: 0.7974 (0.8871)  loss_bbox_aux_1: 0.2866 (0.2899)  loss_giou_aux_1: 0.4297 (0.4616)  loss_fgl_aux_1: 1.1014 (1.1078)  loss_ddf_aux_1: 0.0027 (0.0029)  loss_mal_pre: 0.9111 (0.9398)  loss_bbox_pre: 0.2933 (0.3028)  loss_giou_pre: 0.4562 (0.4847)  loss_mal_enc_0: 0.9741 (1.0158)  loss_bbox_enc_0: 0.3744 (0.3735)  loss_giou_enc_0: 0.5458 (0.5907)  loss_mal_dn_0: 0.6938 (0.7163)  loss_bbox_dn_0: 0.2926 (0.3358)  loss_giou_dn_0: 0.4553 (0.5228)  loss_fgl_dn_0: 1.1906 (1.1849)  loss_ddf_dn_0: 0.2378 (0.2068)  loss_mal_dn_1: 0.5801 (0.6396)  loss_bbox_dn_1: 0.2615 (0.2860)  loss_giou_dn_1: 0.3475 (0.4324)  loss_fgl_dn_1: 1.0924 (1.1053)  loss_ddf_dn_1: 0.0075 (0.0076)  loss_mal_dn_2: 0.5708 (0.6315)  loss_bbox_dn_2: 0.2592 (0.2828)  loss_giou_dn_2: 0.3407 (0.4274)  loss_fgl_dn_2: 1.0882 (1.1023)  loss_mal_dn_pre: 0.6963 (0.7158)  loss_bbox_dn_pre: 0.3012 (0.3370)  loss_giou_dn_pre: 0.4658 (0.5233)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:03<00:00, 11.82it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.721\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.928\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.837\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.339\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.454\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.752\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.737\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.824\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.850\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.631\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.878\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.983\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.951\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:00:51.699\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:00:51.701\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 8 / mAP: 0.7213677004267406\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:00:51.702\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 8, 'coco_eval_bbox': 0.7213677004267406}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:00:51.702\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 9/10\u001b[0m\n",
+      "Epoch 9: 100%|██████████| 403/403 [01:44<00:00,  3.85it/s, loss=18.4034]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 19.4313 (21.0696)  loss_mal: 0.7334 (0.8388)  loss_bbox: 0.2522 (0.2773)  loss_giou: 0.4071 (0.4479)  loss_fgl: 1.0911 (1.1052)  loss_mal_aux_0: 0.8696 (0.9130)  loss_bbox_aux_0: 0.2579 (0.2887)  loss_giou_aux_0: 0.4319 (0.4694)  loss_fgl_aux_0: 1.1259 (1.1378)  loss_ddf_aux_0: 0.0637 (0.0583)  loss_mal_aux_1: 0.7939 (0.8553)  loss_bbox_aux_1: 0.2525 (0.2780)  loss_giou_aux_1: 0.4103 (0.4491)  loss_fgl_aux_1: 1.0909 (1.1066)  loss_ddf_aux_1: 0.0026 (0.0025)  loss_mal_pre: 0.8242 (0.9119)  loss_bbox_pre: 0.2588 (0.2878)  loss_giou_pre: 0.4267 (0.4687)  loss_mal_enc_0: 0.9780 (0.9872)  loss_bbox_enc_0: 0.3137 (0.3498)  loss_giou_enc_0: 0.5208 (0.5668)  loss_mal_dn_0: 0.6807 (0.7077)  loss_bbox_dn_0: 0.3178 (0.3183)  loss_giou_dn_0: 0.4330 (0.5050)  loss_fgl_dn_0: 1.1695 (1.1829)  loss_ddf_dn_0: 0.1982 (0.1975)  loss_mal_dn_1: 0.5850 (0.6269)  loss_bbox_dn_1: 0.2701 (0.2714)  loss_giou_dn_1: 0.3544 (0.4194)  loss_fgl_dn_1: 1.0896 (1.1012)  loss_ddf_dn_1: 0.0064 (0.0069)  loss_mal_dn_2: 0.5703 (0.6186)  loss_bbox_dn_2: 0.2657 (0.2683)  loss_giou_dn_2: 0.3517 (0.4148)  loss_fgl_dn_2: 1.0838 (1.0982)  loss_mal_dn_pre: 0.6821 (0.7071)  loss_bbox_dn_pre: 0.3198 (0.3197)  loss_giou_dn_pre: 0.4266 (0.5053)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:03<00:00, 11.70it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.09s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.724\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.929\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.836\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.287\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.508\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.751\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.737\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.824\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.848\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.338\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.663\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.873\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.986\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.946\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:02:39.891\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:02:39.892\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 9 / mAP: 0.7236852659807308\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:02:39.894\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 9, 'coco_eval_bbox': 0.7236852659807308}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:02:39.895\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m555\u001b[0m - \u001b[1mTraining completed in 0:16:56\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:02:39.895\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m556\u001b[0m - \u001b[1mBest stats: {'epoch': 9, 'coco_eval_bbox': 0.7236852659807308}\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "from deimkit import Config, Trainer, configure_dataset, configure_model\n",
+    "\n",
+    "conf = Config.from_model_name(\"deim_hgnetv2_s\")\n",
+    "\n",
+    "conf = configure_model(conf, num_queries=100, freeze_at=0, pretrained=True)\n",
+    "\n",
+    "conf = configure_dataset(\n",
+    "    config=conf,\n",
+    "    image_size=(320, 320),\n",
+    "    train_ann_file=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train/_annotations.coco.json\",\n",
+    "    train_img_folder=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train\",\n",
+    "    val_ann_file=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid/_annotations.coco.json\",\n",
+    "    val_img_folder=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid\",\n",
+    "    train_batch_size=16,\n",
+    "    val_batch_size=16,\n",
+    "    num_classes=4,\n",
+    "    remap_mscoco=False,\n",
+    "    output_dir=\"./outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px\",\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(conf)\n",
+    "\n",
+    "trainer.load_checkpoint(\"./outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_128px/best.pth\")\n",
+    "trainer.fit(epochs=10, save_best_only=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train at 640px for 10 epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:04:04.004\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.DFINETransformer.num_queries' to: 100\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.005\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.PostProcessor.num_top_queries' to: 100\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.005\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.HGNetv2.pretrained' to: True\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.006\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.HGNetv2.freeze_at' to: -1\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.006\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_init_process_group\u001b[0m:\u001b[36m60\u001b[0m - \u001b[1mInitializing process group for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.020\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_checkpoint\u001b[0m:\u001b[36m624\u001b[0m - \u001b[1mLoading checkpoint from outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.356\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m152\u001b[0m - \u001b[1mDisabling sync_bn and find_unused_parameters for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.357\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m164\u001b[0m - \u001b[1mSet device in config: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.357\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m174\u001b[0m - \u001b[1mInitializing solver for task: detection\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded stage1 B0 HGNetV2 from local file.\n",
+      "Initial lr: [0.0002, 0.0004, 0.0004]\n",
+      "building train_dataloader with batch_size=16...\n",
+      "     ### Transform @Mosaic ###    \n",
+      "     ### Transform @RandomPhotometricDistort ###    \n",
+      "     ### Transform @RandomZoomOut ###    \n",
+      "     ### Transform @RandomIoUCrop ###    \n",
+      "     ### Transform @SanitizeBoundingBoxes ###    \n",
+      "     ### Transform @RandomHorizontalFlip ###    \n",
+      "     ### Transform @Resize ###    \n",
+      "     ### Transform @SanitizeBoundingBoxes ###    \n",
+      "     ### Transform @ConvertPILImage ###    \n",
+      "     ### Transform @ConvertBoxes ###    \n",
+      "     ### Mosaic with Prob.@0.5 and ZoomOut/IoUCrop existed ### \n",
+      "     ### ImgTransforms Epochs: [4, 64, 120] ### \n",
+      "     ### Policy_ops@['Mosaic', 'RandomPhotometricDistort', 'RandomZoomOut', 'RandomIoUCrop'] ###\n",
+      "     ### Using MixUp with Prob@0.5 in [4, 64] epochs ### \n",
+      "     ### Multi-scale Training until 120 epochs ### \n",
+      "     ### Multi-scales@ [480, 512, 544, 576, 608, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 800, 768, 736, 704, 672] ###        \n",
+      "building val_dataloader with batch_size=16...\n",
+      "     ### Transform @Resize ###    \n",
+      "     ### Transform @ConvertPILImage ###    \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:04:04.595\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m201\u001b[0m - \u001b[1mTraining setup complete. Output directory: outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.596\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m203\u001b[0m - \u001b[1mSaving config to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px/config.yml\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.628\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m642\u001b[0m - \u001b[33m\u001b[1mShape mismatch, loading compatible parameters only: Error(s) in loading state_dict for DistributedDataParallel:\n",
+      "\tsize mismatch for module.decoder.anchors: copying a param with shape torch.Size([1, 2100, 4]) from checkpoint, the shape in current model is torch.Size([1, 8400, 4]).\n",
+      "\tsize mismatch for module.decoder.valid_mask: copying a param with shape torch.Size([1, 2100, 1]) from checkpoint, the shape in current model is torch.Size([1, 8400, 1]).\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.670\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m649\u001b[0m - \u001b[1mLoaded parameters with matching shapes\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.703\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_checkpoint\u001b[0m:\u001b[36m659\u001b[0m - \u001b[1mAttempting to load EMA parameters with matching shapes...\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.736\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m642\u001b[0m - \u001b[33m\u001b[1mShape mismatch, loading compatible parameters only: Error(s) in loading state_dict for DEIM:\n",
+      "\tsize mismatch for decoder.anchors: copying a param with shape torch.Size([1, 2100, 4]) from checkpoint, the shape in current model is torch.Size([1, 8400, 4]).\n",
+      "\tsize mismatch for decoder.valid_mask: copying a param with shape torch.Size([1, 2100, 1]) from checkpoint, the shape in current model is torch.Size([1, 8400, 1]).\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.765\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m649\u001b[0m - \u001b[1mLoaded parameters with matching shapes\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.767\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_checkpoint\u001b[0m:\u001b[36m667\u001b[0m - \u001b[33m\u001b[1mCould not load optimizer state: loaded state dict contains a parameter group that doesn't match the size of optimizer's group\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.767\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_checkpoint\u001b[0m:\u001b[36m671\u001b[0m - \u001b[1mLoaded checkpoint from epoch 9\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.772\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m239\u001b[0m - \u001b[1mStarting training...\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.772\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m242\u001b[0m - \u001b[1mOverriding epochs to 10\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.773\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m276\u001b[0m - \u001b[1mSetting pretrained flag to True for HGNetv2\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.773\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m296\u001b[0m - \u001b[1mAutomatically calculated mixup epochs: [1, 5]\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.773\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m306\u001b[0m - \u001b[1mAutomatically calculated data augmentation epochs: 1, 5, 9\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.773\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m315\u001b[0m - \u001b[1mAutomatically calculated stop epoch: 9\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.774\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m323\u001b[0m - \u001b[1mAutomatically calculated no augmentation epochs: 1\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.774\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m336\u001b[0m - \u001b[1mAutomatically calculated flat epochs: 5\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.778\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m363\u001b[0m - \u001b[1mAutomatically calculated warmup iterations: 403 (1.0 epochs)\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.778\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m376\u001b[0m - \u001b[1mAutomatically calculated EMA warmups: 403 (1.0 epochs)\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.779\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m152\u001b[0m - \u001b[1mDisabling sync_bn and find_unused_parameters for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.779\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m164\u001b[0m - \u001b[1mSet device in config: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.779\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m174\u001b[0m - \u001b[1mInitializing solver for task: detection\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.814\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m201\u001b[0m - \u001b[1mTraining setup complete. Output directory: outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.815\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m203\u001b[0m - \u001b[1mSaving config to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px/config.yml\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.821\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m384\u001b[0m - \u001b[1mUsing device: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.950\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.951\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m393\u001b[0m - \u001b[1mInitial model saved as best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.953\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m403\u001b[0m - \u001b[1mNumber of trainable parameters: 10224291\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.954\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m409\u001b[0m - \u001b[1mUsing custom scheduler: flatcosine\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:04:04.954\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 0/10\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.0002, 0.0004, 0.0004] [0.0001, 0.0002, 0.0002] 4030 403 2015 403\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 403/403 [02:05<00:00,  3.22it/s, loss=19.7360]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000199  loss: 20.2041 (23.8474)  loss_mal: 0.7686 (1.0248)  loss_bbox: 0.2423 (0.3499)  loss_giou: 0.2666 (0.3208)  loss_fgl: 1.0590 (1.0833)  loss_mal_aux_0: 0.9053 (1.2186)  loss_bbox_aux_0: 0.3274 (0.4187)  loss_giou_aux_0: 0.3040 (0.3853)  loss_fgl_aux_0: 1.1622 (1.1714)  loss_ddf_aux_0: 0.0879 (0.1069)  loss_mal_aux_1: 0.7959 (1.0851)  loss_bbox_aux_1: 0.2489 (0.3580)  loss_giou_aux_1: 0.2500 (0.3280)  loss_fgl_aux_1: 1.0642 (1.0922)  loss_ddf_aux_1: 0.0063 (0.0072)  loss_mal_pre: 0.9053 (1.2158)  loss_bbox_pre: 0.3138 (0.4187)  loss_giou_pre: 0.3039 (0.3845)  loss_mal_enc_0: 1.0957 (1.7321)  loss_bbox_enc_0: 0.5337 (0.7445)  loss_giou_enc_0: 0.4783 (0.6213)  loss_mal_dn_0: 0.6899 (0.7251)  loss_bbox_dn_0: 0.4430 (0.5263)  loss_giou_dn_0: 0.4270 (0.4841)  loss_fgl_dn_0: 1.2296 (1.2457)  loss_ddf_dn_0: 0.2340 (0.2532)  loss_mal_dn_1: 0.5605 (0.6040)  loss_bbox_dn_1: 0.3024 (0.3813)  loss_giou_dn_1: 0.3020 (0.3404)  loss_fgl_dn_1: 1.0771 (1.1033)  loss_ddf_dn_1: 0.0157 (0.0177)  loss_mal_dn_2: 0.5498 (0.5857)  loss_bbox_dn_2: 0.2799 (0.3608)  loss_giou_dn_2: 0.2842 (0.3222)  loss_fgl_dn_2: 1.0597 (1.0887)  loss_mal_dn_pre: 0.6865 (0.7233)  loss_bbox_dn_pre: 0.4548 (0.5349)  loss_giou_dn_pre: 0.4227 (0.4835)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.26it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.626\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.840\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.731\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.314\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.353\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.659\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.690\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.801\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.836\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.325\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.668\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.860\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.986\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.948\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:06:15.599\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:06:15.601\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 0 / mAP: 0.6263842752627564\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:06:15.602\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 0, 'coco_eval_bbox': 0.6263842752627564}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:06:15.602\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 1/10\u001b[0m\n",
+      "Epoch 1: 100%|██████████| 403/403 [02:03<00:00,  3.26it/s, loss=17.2695]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 17.8040 (19.9852)  loss_mal: 0.5586 (0.7442)  loss_bbox: 0.2058 (0.2662)  loss_giou: 0.2253 (0.2599)  loss_fgl: 1.0045 (1.0608)  loss_mal_aux_0: 0.7388 (0.9060)  loss_bbox_aux_0: 0.2947 (0.3206)  loss_giou_aux_0: 0.2672 (0.3124)  loss_fgl_aux_0: 1.1053 (1.1593)  loss_ddf_aux_0: 0.1147 (0.1199)  loss_mal_aux_1: 0.6206 (0.7711)  loss_bbox_aux_1: 0.2141 (0.2704)  loss_giou_aux_1: 0.2252 (0.2641)  loss_fgl_aux_1: 1.0073 (1.0671)  loss_ddf_aux_1: 0.0067 (0.0083)  loss_mal_pre: 0.7344 (0.9063)  loss_bbox_pre: 0.2867 (0.3183)  loss_giou_pre: 0.2660 (0.3100)  loss_mal_enc_0: 0.8838 (1.0886)  loss_bbox_enc_0: 0.4497 (0.5233)  loss_giou_enc_0: 0.4108 (0.4766)  loss_mal_dn_0: 0.6523 (0.6847)  loss_bbox_dn_0: 0.3641 (0.4152)  loss_giou_dn_0: 0.3638 (0.4039)  loss_fgl_dn_0: 1.2131 (1.2286)  loss_ddf_dn_0: 0.3071 (0.2894)  loss_mal_dn_1: 0.5088 (0.5480)  loss_bbox_dn_1: 0.2106 (0.2784)  loss_giou_dn_1: 0.2272 (0.2722)  loss_fgl_dn_1: 1.0274 (1.0695)  loss_ddf_dn_1: 0.0180 (0.0211)  loss_mal_dn_2: 0.4805 (0.5334)  loss_bbox_dn_2: 0.2128 (0.2643)  loss_giou_dn_2: 0.2269 (0.2599)  loss_fgl_dn_2: 1.0125 (1.0554)  loss_mal_dn_pre: 0.6489 (0.6833)  loss_bbox_dn_pre: 0.3738 (0.4210)  loss_giou_dn_pre: 0.3677 (0.4034)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.33it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.711\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.908\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.840\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.275\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.499\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.739\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.731\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.836\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.863\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.388\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.724\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.883\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.968\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:08:24.610\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:08:24.612\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 1 / mAP: 0.7108833396119187\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:08:24.613\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 1, 'coco_eval_bbox': 0.7108833396119187}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:08:24.613\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 2/10\u001b[0m\n",
+      "Epoch 2: 100%|██████████| 403/403 [02:03<00:00,  3.26it/s, loss=15.5036]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 17.2093 (18.4256)  loss_mal: 0.5381 (0.6228)  loss_bbox: 0.2058 (0.2270)  loss_giou: 0.1944 (0.2275)  loss_fgl: 0.9688 (1.0203)  loss_mal_aux_0: 0.7036 (0.7940)  loss_bbox_aux_0: 0.2504 (0.2816)  loss_giou_aux_0: 0.2313 (0.2806)  loss_fgl_aux_0: 1.0883 (1.1328)  loss_ddf_aux_0: 0.1193 (0.1286)  loss_mal_aux_1: 0.5552 (0.6554)  loss_bbox_aux_1: 0.2252 (0.2301)  loss_giou_aux_1: 0.1973 (0.2305)  loss_fgl_aux_1: 0.9839 (1.0268)  loss_ddf_aux_1: 0.0073 (0.0082)  loss_mal_pre: 0.6909 (0.7934)  loss_bbox_pre: 0.2482 (0.2782)  loss_giou_pre: 0.2266 (0.2779)  loss_mal_enc_0: 0.9380 (0.9684)  loss_bbox_enc_0: 0.3854 (0.4719)  loss_giou_enc_0: 0.3959 (0.4337)  loss_mal_dn_0: 0.6401 (0.6554)  loss_bbox_dn_0: 0.3428 (0.3716)  loss_giou_dn_0: 0.3404 (0.3699)  loss_fgl_dn_0: 1.1984 (1.2165)  loss_ddf_dn_0: 0.2770 (0.3174)  loss_mal_dn_1: 0.4763 (0.5059)  loss_bbox_dn_1: 0.2064 (0.2393)  loss_giou_dn_1: 0.2173 (0.2400)  loss_fgl_dn_1: 1.0073 (1.0329)  loss_ddf_dn_1: 0.0171 (0.0212)  loss_mal_dn_2: 0.4583 (0.4901)  loss_bbox_dn_2: 0.2024 (0.2280)  loss_giou_dn_2: 0.2120 (0.2298)  loss_fgl_dn_2: 0.9730 (1.0170)  loss_mal_dn_pre: 0.6401 (0.6540)  loss_bbox_dn_pre: 0.3563 (0.3772)  loss_giou_dn_pre: 0.3414 (0.3694)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.37it/s]\n",
+      "\u001b[32m2025-04-03 15:10:33.286\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 1, 'coco_eval_bbox': 0.7108833396119187}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:10:33.287\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 3/10\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.709\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.907\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.835\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.316\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.500\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.737\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.737\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.833\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.866\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.388\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.743\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.885\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.973\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 3: 100%|██████████| 403/403 [02:04<00:00,  3.23it/s, loss=14.2713]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 16.7738 (17.3298)  loss_mal: 0.4617 (0.5625)  loss_bbox: 0.1899 (0.2021)  loss_giou: 0.1826 (0.2092)  loss_fgl: 0.9620 (0.9963)  loss_mal_aux_0: 0.5947 (0.7073)  loss_bbox_aux_0: 0.2358 (0.2520)  loss_giou_aux_0: 0.2323 (0.2582)  loss_fgl_aux_0: 1.0668 (1.1070)  loss_ddf_aux_0: 0.1225 (0.1294)  loss_mal_aux_1: 0.5278 (0.5896)  loss_bbox_aux_1: 0.1906 (0.2047)  loss_giou_aux_1: 0.1903 (0.2124)  loss_fgl_aux_1: 0.9778 (1.0019)  loss_ddf_aux_1: 0.0062 (0.0087)  loss_mal_pre: 0.5898 (0.7053)  loss_bbox_pre: 0.2317 (0.2494)  loss_giou_pre: 0.2293 (0.2554)  loss_mal_enc_0: 0.7856 (0.8946)  loss_bbox_enc_0: 0.4176 (0.4316)  loss_giou_enc_0: 0.3991 (0.4060)  loss_mal_dn_0: 0.6064 (0.6300)  loss_bbox_dn_0: 0.3240 (0.3371)  loss_giou_dn_0: 0.3163 (0.3420)  loss_fgl_dn_0: 1.1748 (1.2027)  loss_ddf_dn_0: 0.3138 (0.3349)  loss_mal_dn_1: 0.4468 (0.4717)  loss_bbox_dn_1: 0.1841 (0.2125)  loss_giou_dn_1: 0.1951 (0.2182)  loss_fgl_dn_1: 0.9640 (1.0052)  loss_ddf_dn_1: 0.0184 (0.0226)  loss_mal_dn_2: 0.4243 (0.4553)  loss_bbox_dn_2: 0.1709 (0.2019)  loss_giou_dn_2: 0.1826 (0.2087)  loss_fgl_dn_2: 0.9476 (0.9893)  loss_mal_dn_pre: 0.6074 (0.6286)  loss_bbox_dn_pre: 0.3392 (0.3432)  loss_giou_dn_pre: 0.3142 (0.3419)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.18it/s]\n",
+      "\u001b[32m2025-04-03 15:12:43.224\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 1, 'coco_eval_bbox': 0.7108833396119187}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:12:43.224\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 4/10\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.704\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.899\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.807\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.277\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.526\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.730\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.728\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.835\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.856\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.388\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.703\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.876\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.960\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 4: 100%|██████████| 403/403 [02:40<00:00,  2.51it/s, loss=24.6277]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 19.0734 (22.3633)  loss_mal: 0.7783 (0.9138)  loss_bbox: 0.1687 (0.3360)  loss_giou: 0.3176 (0.4703)  loss_fgl: 1.0693 (1.1055)  loss_mal_aux_0: 0.8750 (0.9811)  loss_bbox_aux_0: 0.1949 (0.3549)  loss_giou_aux_0: 0.3745 (0.5055)  loss_fgl_aux_0: 1.1343 (1.1485)  loss_ddf_aux_0: 0.0804 (0.0972)  loss_mal_aux_1: 0.7568 (0.9255)  loss_bbox_aux_1: 0.1682 (0.3369)  loss_giou_aux_1: 0.3132 (0.4722)  loss_fgl_aux_1: 1.0706 (1.1068)  loss_ddf_aux_1: 0.0041 (0.0049)  loss_mal_pre: 0.8765 (0.9803)  loss_bbox_pre: 0.1880 (0.3538)  loss_giou_pre: 0.3682 (0.5043)  loss_mal_enc_0: 0.9756 (1.0360)  loss_bbox_enc_0: 0.3641 (0.4444)  loss_giou_enc_0: 0.5991 (0.6284)  loss_mal_dn_0: 0.6855 (0.7269)  loss_bbox_dn_0: 0.2680 (0.3560)  loss_giou_dn_0: 0.4440 (0.5360)  loss_fgl_dn_0: 1.1919 (1.1971)  loss_ddf_dn_0: 0.2278 (0.2664)  loss_mal_dn_1: 0.5850 (0.6452)  loss_bbox_dn_1: 0.2096 (0.3024)  loss_giou_dn_1: 0.3080 (0.4273)  loss_fgl_dn_1: 1.0824 (1.1060)  loss_ddf_dn_1: 0.0126 (0.0138)  loss_mal_dn_2: 0.5825 (0.6384)  loss_bbox_dn_2: 0.2023 (0.2992)  loss_giou_dn_2: 0.2978 (0.4206)  loss_fgl_dn_2: 1.0817 (1.1022)  loss_mal_dn_pre: 0.6870 (0.7270)  loss_bbox_dn_pre: 0.2658 (0.3567)  loss_giou_dn_pre: 0.4360 (0.5361)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.32it/s]\n",
+      "\u001b[32m2025-04-03 15:15:28.748\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 1, 'coco_eval_bbox': 0.7108833396119187}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:15:28.749\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 5/10\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.693\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.905\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.822\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.321\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.493\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.718\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.712\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.802\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.831\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.600\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.854\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.982\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.941\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 5: 100%|██████████| 403/403 [02:40<00:00,  2.51it/s, loss=24.3611]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000185  loss: 23.2214 (21.4024)  loss_mal: 0.9258 (0.8593)  loss_bbox: 0.3390 (0.3006)  loss_giou: 0.4871 (0.4229)  loss_fgl: 1.0981 (1.0944)  loss_mal_aux_0: 0.9917 (0.9367)  loss_bbox_aux_0: 0.3444 (0.3196)  loss_giou_aux_0: 0.5169 (0.4562)  loss_fgl_aux_0: 1.1293 (1.1449)  loss_ddf_aux_0: 0.1005 (0.1030)  loss_mal_aux_1: 0.9609 (0.8761)  loss_bbox_aux_1: 0.3411 (0.3016)  loss_giou_aux_1: 0.4873 (0.4248)  loss_fgl_aux_1: 1.0976 (1.0959)  loss_ddf_aux_1: 0.0043 (0.0046)  loss_mal_pre: 0.9922 (0.9348)  loss_bbox_pre: 0.3446 (0.3189)  loss_giou_pre: 0.5191 (0.4551)  loss_mal_enc_0: 1.0322 (1.0153)  loss_bbox_enc_0: 0.4655 (0.4189)  loss_giou_enc_0: 0.6372 (0.5885)  loss_mal_dn_0: 0.7480 (0.7118)  loss_bbox_dn_0: 0.3774 (0.3379)  loss_giou_dn_0: 0.5570 (0.5013)  loss_fgl_dn_0: 1.1886 (1.1971)  loss_ddf_dn_0: 0.2293 (0.2702)  loss_mal_dn_1: 0.6816 (0.6208)  loss_bbox_dn_1: 0.3286 (0.2817)  loss_giou_dn_1: 0.4650 (0.3936)  loss_fgl_dn_1: 1.1017 (1.0897)  loss_ddf_dn_1: 0.0098 (0.0125)  loss_mal_dn_2: 0.6753 (0.6122)  loss_bbox_dn_2: 0.3250 (0.2777)  loss_giou_dn_2: 0.4577 (0.3867)  loss_fgl_dn_2: 1.0984 (1.0852)  loss_mal_dn_pre: 0.7480 (0.7113)  loss_bbox_dn_pre: 0.3771 (0.3390)  loss_giou_dn_pre: 0.5626 (0.5012)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.10it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.720\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.924\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.839\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.338\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.501\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.746\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.731\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.805\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.841\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.669\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.862\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.951\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:18:14.497\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:18:14.499\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 5 / mAP: 0.7203544737640822\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:18:14.500\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 5, 'coco_eval_bbox': 0.7203544737640822}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:18:14.500\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 6/10\u001b[0m\n",
+      "Epoch 6: 100%|██████████| 403/403 [02:39<00:00,  2.53it/s, loss=17.8950]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000150  loss: 19.0610 (20.5931)  loss_mal: 0.7261 (0.8144)  loss_bbox: 0.2391 (0.2755)  loss_giou: 0.3635 (0.4031)  loss_fgl: 1.0757 (1.0795)  loss_mal_aux_0: 0.8506 (0.8887)  loss_bbox_aux_0: 0.2488 (0.2942)  loss_giou_aux_0: 0.3798 (0.4354)  loss_fgl_aux_0: 1.1155 (1.1330)  loss_ddf_aux_0: 0.0926 (0.1034)  loss_mal_aux_1: 0.7568 (0.8267)  loss_bbox_aux_1: 0.2455 (0.2767)  loss_giou_aux_1: 0.3627 (0.4051)  loss_fgl_aux_1: 1.0733 (1.0820)  loss_ddf_aux_1: 0.0040 (0.0046)  loss_mal_pre: 0.8369 (0.8867)  loss_bbox_pre: 0.2496 (0.2933)  loss_giou_pre: 0.3763 (0.4341)  loss_mal_enc_0: 0.9453 (0.9795)  loss_bbox_enc_0: 0.3379 (0.3858)  loss_giou_enc_0: 0.5095 (0.5610)  loss_mal_dn_0: 0.6724 (0.6971)  loss_bbox_dn_0: 0.2926 (0.3116)  loss_giou_dn_0: 0.4103 (0.4738)  loss_fgl_dn_0: 1.1859 (1.1911)  loss_ddf_dn_0: 0.2628 (0.2711)  loss_mal_dn_1: 0.5625 (0.6006)  loss_bbox_dn_1: 0.2422 (0.2574)  loss_giou_dn_1: 0.3074 (0.3713)  loss_fgl_dn_1: 1.0603 (1.0783)  loss_ddf_dn_1: 0.0089 (0.0113)  loss_mal_dn_2: 0.5601 (0.5917)  loss_bbox_dn_2: 0.2348 (0.2537)  loss_giou_dn_2: 0.3006 (0.3651)  loss_fgl_dn_2: 1.0521 (1.0735)  loss_mal_dn_pre: 0.6719 (0.6966)  loss_bbox_dn_pre: 0.2904 (0.3127)  loss_giou_dn_pre: 0.4061 (0.4737)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.22it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.739\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.932\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.854\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.338\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.511\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.767\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.737\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.831\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.864\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.699\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.887\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.948\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:20:59.260\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:20:59.262\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 6 / mAP: 0.7387354002519992\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:20:59.263\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 6, 'coco_eval_bbox': 0.7387354002519992}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:20:59.264\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 7/10\u001b[0m\n",
+      "Epoch 7: 100%|██████████| 403/403 [02:40<00:00,  2.50it/s, loss=14.9711]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000115  loss: 17.7794 (20.0591)  loss_mal: 0.6362 (0.7815)  loss_bbox: 0.2061 (0.2667)  loss_giou: 0.3034 (0.3897)  loss_fgl: 1.0369 (1.0709)  loss_mal_aux_0: 0.7095 (0.8647)  loss_bbox_aux_0: 0.2395 (0.2811)  loss_giou_aux_0: 0.3319 (0.4162)  loss_fgl_aux_0: 1.0919 (1.1205)  loss_ddf_aux_0: 0.0971 (0.0917)  loss_mal_aux_1: 0.6406 (0.8001)  loss_bbox_aux_1: 0.2043 (0.2677)  loss_giou_aux_1: 0.3103 (0.3915)  loss_fgl_aux_1: 1.0467 (1.0732)  loss_ddf_aux_1: 0.0045 (0.0042)  loss_mal_pre: 0.7065 (0.8637)  loss_bbox_pre: 0.2411 (0.2798)  loss_giou_pre: 0.3299 (0.4150)  loss_mal_enc_0: 0.8711 (0.9575)  loss_bbox_enc_0: 0.3086 (0.3664)  loss_giou_enc_0: 0.4843 (0.5393)  loss_mal_dn_0: 0.6479 (0.6816)  loss_bbox_dn_0: 0.2549 (0.2998)  loss_giou_dn_0: 0.3688 (0.4520)  loss_fgl_dn_0: 1.1705 (1.1826)  loss_ddf_dn_0: 0.2659 (0.2621)  loss_mal_dn_1: 0.5190 (0.5835)  loss_bbox_dn_1: 0.1928 (0.2499)  loss_giou_dn_1: 0.2833 (0.3575)  loss_fgl_dn_1: 1.0344 (1.0680)  loss_ddf_dn_1: 0.0096 (0.0103)  loss_mal_dn_2: 0.5132 (0.5741)  loss_bbox_dn_2: 0.1857 (0.2466)  loss_giou_dn_2: 0.2725 (0.3518)  loss_fgl_dn_2: 1.0332 (1.0636)  loss_mal_dn_pre: 0.6489 (0.6811)  loss_bbox_dn_pre: 0.2531 (0.3013)  loss_giou_dn_pre: 0.3776 (0.4520)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.22it/s]\n",
+      "\u001b[32m2025-04-03 15:23:45.248\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 6, 'coco_eval_bbox': 0.7387354002519992}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:23:45.248\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 8/10\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.738\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.930\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.854\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.351\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.511\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.766\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.743\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.824\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.855\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.695\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.876\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.943\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 8: 100%|██████████| 403/403 [02:40<00:00,  2.51it/s, loss=15.9677]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 20.9026 (19.5518)  loss_mal: 0.8857 (0.7554)  loss_bbox: 0.2829 (0.2548)  loss_giou: 0.3891 (0.3734)  loss_fgl: 1.0819 (1.0618)  loss_mal_aux_0: 0.9077 (0.8340)  loss_bbox_aux_0: 0.2791 (0.2692)  loss_giou_aux_0: 0.4154 (0.3984)  loss_fgl_aux_0: 1.1180 (1.1106)  loss_ddf_aux_0: 0.0870 (0.0907)  loss_mal_aux_1: 0.8916 (0.7702)  loss_bbox_aux_1: 0.2823 (0.2559)  loss_giou_aux_1: 0.3884 (0.3749)  loss_fgl_aux_1: 1.0843 (1.0642)  loss_ddf_aux_1: 0.0032 (0.0041)  loss_mal_pre: 0.9033 (0.8329)  loss_bbox_pre: 0.2775 (0.2688)  loss_giou_pre: 0.4157 (0.3977)  loss_mal_enc_0: 0.9785 (0.9376)  loss_bbox_enc_0: 0.3772 (0.3580)  loss_giou_enc_0: 0.5297 (0.5213)  loss_mal_dn_0: 0.7041 (0.6682)  loss_bbox_dn_0: 0.3178 (0.2886)  loss_giou_dn_0: 0.4936 (0.4335)  loss_fgl_dn_0: 1.1709 (1.1741)  loss_ddf_dn_0: 0.2250 (0.2541)  loss_mal_dn_1: 0.6270 (0.5681)  loss_bbox_dn_1: 0.2775 (0.2400)  loss_giou_dn_1: 0.4214 (0.3441)  loss_fgl_dn_1: 1.0829 (1.0578)  loss_ddf_dn_1: 0.0076 (0.0088)  loss_mal_dn_2: 0.6143 (0.5593)  loss_bbox_dn_2: 0.2746 (0.2369)  loss_giou_dn_2: 0.4144 (0.3391)  loss_fgl_dn_2: 1.0775 (1.0535)  loss_mal_dn_pre: 0.7031 (0.6677)  loss_bbox_dn_pre: 0.3155 (0.2905)  loss_giou_dn_pre: 0.4919 (0.4335)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.17it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.741\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.938\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.855\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.351\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.527\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.768\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.738\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.829\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.854\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.676\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.878\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.945\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:26:31.187\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:26:31.188\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 8 / mAP: 0.7414413671319263\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:26:31.189\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 8, 'coco_eval_bbox': 0.7414413671319263}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:26:31.190\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 9/10\u001b[0m\n",
+      "Epoch 9: 100%|██████████| 403/403 [02:39<00:00,  2.52it/s, loss=21.5467]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 17.7919 (19.1302)  loss_mal: 0.6045 (0.7290)  loss_bbox: 0.1822 (0.2462)  loss_giou: 0.3144 (0.3585)  loss_fgl: 1.0386 (1.0520)  loss_mal_aux_0: 0.7017 (0.8078)  loss_bbox_aux_0: 0.2110 (0.2605)  loss_giou_aux_0: 0.3433 (0.3841)  loss_fgl_aux_0: 1.0868 (1.1024)  loss_ddf_aux_0: 0.1013 (0.0922)  loss_mal_aux_1: 0.6123 (0.7447)  loss_bbox_aux_1: 0.1857 (0.2472)  loss_giou_aux_1: 0.3158 (0.3601)  loss_fgl_aux_1: 1.0446 (1.0541)  loss_ddf_aux_1: 0.0035 (0.0040)  loss_mal_pre: 0.7017 (0.8062)  loss_bbox_pre: 0.2033 (0.2602)  loss_giou_pre: 0.3413 (0.3832)  loss_mal_enc_0: 0.8970 (0.9153)  loss_bbox_enc_0: 0.3245 (0.3435)  loss_giou_enc_0: 0.4604 (0.4995)  loss_mal_dn_0: 0.6421 (0.6606)  loss_bbox_dn_0: 0.2374 (0.2812)  loss_giou_dn_0: 0.3691 (0.4209)  loss_fgl_dn_0: 1.1704 (1.1688)  loss_ddf_dn_0: 0.2761 (0.2576)  loss_mal_dn_1: 0.5137 (0.5572)  loss_bbox_dn_1: 0.1789 (0.2328)  loss_giou_dn_1: 0.2726 (0.3331)  loss_fgl_dn_1: 1.0300 (1.0461)  loss_ddf_dn_1: 0.0079 (0.0084)  loss_mal_dn_2: 0.5059 (0.5487)  loss_bbox_dn_2: 0.1736 (0.2298)  loss_giou_dn_2: 0.2691 (0.3285)  loss_fgl_dn_2: 1.0183 (1.0418)  loss_mal_dn_pre: 0.6411 (0.6602)  loss_bbox_dn_pre: 0.2412 (0.2828)  loss_giou_dn_pre: 0.3676 (0.4208)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.18it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.747\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.938\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.862\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.339\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.539\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.774\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.741\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.823\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.853\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.708\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.874\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.986\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.953\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:29:16.342\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:29:16.344\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 9 / mAP: 0.747488341563501\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:29:16.346\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 9, 'coco_eval_bbox': 0.747488341563501}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:29:16.346\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m555\u001b[0m - \u001b[1mTraining completed in 0:25:11\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:29:16.347\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m556\u001b[0m - \u001b[1mBest stats: {'epoch': 9, 'coco_eval_bbox': 0.747488341563501}\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "from deimkit import Config, Trainer, configure_dataset, configure_model\n",
+    "\n",
+    "conf = Config.from_model_name(\"deim_hgnetv2_s\")\n",
+    "\n",
+    "conf = configure_model(conf, num_queries=100, freeze_at=-1, pretrained=True)\n",
+    "\n",
+    "conf = configure_dataset(\n",
+    "    config=conf,\n",
+    "    image_size=(640, 640),\n",
+    "    train_ann_file=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train/_annotations.coco.json\",\n",
+    "    train_img_folder=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train\",\n",
+    "    val_ann_file=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid/_annotations.coco.json\",\n",
+    "    val_img_folder=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid\",\n",
+    "    train_batch_size=16,\n",
+    "    val_batch_size=16,\n",
+    "    num_classes=4,\n",
+    "    remap_mscoco=False,\n",
+    "    output_dir=\"./outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px\",\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(conf)\n",
+    "\n",
+    "trainer.load_checkpoint(\"./outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\")\n",
+    "trainer.fit(epochs=10, save_best_only=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:42:59.506\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.DFINETransformer.num_queries' to: 100\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:42:59.506\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.PostProcessor.num_top_queries' to: 100\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:42:59.506\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.HGNetv2.pretrained' to: True\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:42:59.507\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.HGNetv2.freeze_at' to: 0\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:42:59.507\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_init_process_group\u001b[0m:\u001b[36m60\u001b[0m - \u001b[1mInitializing process group for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:42:59.509\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_checkpoint\u001b[0m:\u001b[36m624\u001b[0m - \u001b[1mLoading checkpoint from outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:42:59.729\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m152\u001b[0m - \u001b[1mDisabling sync_bn and find_unused_parameters for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:42:59.730\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m164\u001b[0m - \u001b[1mSet device in config: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:42:59.730\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m174\u001b[0m - \u001b[1mInitializing solver for task: detection\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded stage1 B0 HGNetV2 from local file.\n",
+      "Initial lr: [0.0002, 0.0004, 0.0004]\n",
+      "building train_dataloader with batch_size=16...\n",
+      "     ### Transform @Mosaic ###    \n",
+      "     ### Transform @RandomPhotometricDistort ###    \n",
+      "     ### Transform @RandomZoomOut ###    \n",
+      "     ### Transform @RandomIoUCrop ###    \n",
+      "     ### Transform @SanitizeBoundingBoxes ###    \n",
+      "     ### Transform @RandomHorizontalFlip ###    \n",
+      "     ### Transform @Resize ###    \n",
+      "     ### Transform @SanitizeBoundingBoxes ###    \n",
+      "     ### Transform @ConvertPILImage ###    \n",
+      "     ### Transform @ConvertBoxes ###    \n",
+      "     ### Mosaic with Prob.@0.5 and ZoomOut/IoUCrop existed ### \n",
+      "     ### ImgTransforms Epochs: [4, 64, 120] ### \n",
+      "     ### Policy_ops@['Mosaic', 'RandomPhotometricDistort', 'RandomZoomOut', 'RandomIoUCrop'] ###\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/dnth/Desktop/DEIMKit/src/deimkit/engine/core/workspace.py:180: FutureWarning: `torch.cuda.amp.GradScaler(args...)` is deprecated. Please use `torch.amp.GradScaler('cuda', args...)` instead.\n",
+      "  return module(**module_kwargs)\n",
+      "\u001b[32m2025-04-03 15:43:00.113\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m201\u001b[0m - \u001b[1mTraining setup complete. Output directory: outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.113\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m203\u001b[0m - \u001b[1mSaving config to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0/config.yml\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.145\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m642\u001b[0m - \u001b[33m\u001b[1mShape mismatch, loading compatible parameters only: Error(s) in loading state_dict for DistributedDataParallel:\n",
+      "\tsize mismatch for module.decoder.anchors: copying a param with shape torch.Size([1, 2100, 4]) from checkpoint, the shape in current model is torch.Size([1, 8400, 4]).\n",
+      "\tsize mismatch for module.decoder.valid_mask: copying a param with shape torch.Size([1, 2100, 1]) from checkpoint, the shape in current model is torch.Size([1, 8400, 1]).\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.173\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m649\u001b[0m - \u001b[1mLoaded parameters with matching shapes\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.197\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_checkpoint\u001b[0m:\u001b[36m659\u001b[0m - \u001b[1mAttempting to load EMA parameters with matching shapes...\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.223\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m642\u001b[0m - \u001b[33m\u001b[1mShape mismatch, loading compatible parameters only: Error(s) in loading state_dict for DEIM:\n",
+      "\tsize mismatch for decoder.anchors: copying a param with shape torch.Size([1, 2100, 4]) from checkpoint, the shape in current model is torch.Size([1, 8400, 4]).\n",
+      "\tsize mismatch for decoder.valid_mask: copying a param with shape torch.Size([1, 2100, 1]) from checkpoint, the shape in current model is torch.Size([1, 8400, 1]).\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.252\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_state_dict_with_mismatch\u001b[0m:\u001b[36m649\u001b[0m - \u001b[1mLoaded parameters with matching shapes\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.283\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mload_checkpoint\u001b[0m:\u001b[36m671\u001b[0m - \u001b[1mLoaded checkpoint from epoch 9\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.287\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m239\u001b[0m - \u001b[1mStarting training...\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.288\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m242\u001b[0m - \u001b[1mOverriding epochs to 10\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.288\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m276\u001b[0m - \u001b[1mSetting pretrained flag to True for HGNetv2\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.288\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m296\u001b[0m - \u001b[1mAutomatically calculated mixup epochs: [1, 5]\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.288\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m306\u001b[0m - \u001b[1mAutomatically calculated data augmentation epochs: 1, 5, 9\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.289\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m315\u001b[0m - \u001b[1mAutomatically calculated stop epoch: 9\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.289\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m323\u001b[0m - \u001b[1mAutomatically calculated no augmentation epochs: 1\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.289\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m336\u001b[0m - \u001b[1mAutomatically calculated flat epochs: 5\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.292\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m363\u001b[0m - \u001b[1mAutomatically calculated warmup iterations: 403 (1.0 epochs)\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.292\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m376\u001b[0m - \u001b[1mAutomatically calculated EMA warmups: 403 (1.0 epochs)\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.293\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m152\u001b[0m - \u001b[1mDisabling sync_bn and find_unused_parameters for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.293\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m164\u001b[0m - \u001b[1mSet device in config: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.293\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m174\u001b[0m - \u001b[1mInitializing solver for task: detection\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     ### Using MixUp with Prob@0.5 in [4, 64] epochs ### \n",
+      "     ### Multi-scale Training until 120 epochs ### \n",
+      "     ### Multi-scales@ [480, 512, 544, 576, 608, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 800, 768, 736, 704, 672] ###        \n",
+      "building val_dataloader with batch_size=16...\n",
+      "     ### Transform @Resize ###    \n",
+      "     ### Transform @ConvertPILImage ###    \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:43:00.323\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m201\u001b[0m - \u001b[1mTraining setup complete. Output directory: outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.324\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m203\u001b[0m - \u001b[1mSaving config to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0/config.yml\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.332\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m384\u001b[0m - \u001b[1mUsing device: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.596\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.598\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m393\u001b[0m - \u001b[1mInitial model saved as best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.601\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m403\u001b[0m - \u001b[1mNumber of trainable parameters: 10217817\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.602\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m409\u001b[0m - \u001b[1mUsing custom scheduler: flatcosine\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:43:00.602\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 0/10\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.0002, 0.0004, 0.0004] [0.0001, 0.0002, 0.0002] 4030 403 2015 403\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 403/403 [01:55<00:00,  3.48it/s, loss=18.2400]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000199  loss: 19.6079 (23.4102)  loss_mal: 0.6958 (0.9933)  loss_bbox: 0.2672 (0.3356)  loss_giou: 0.2589 (0.3134)  loss_fgl: 1.0562 (1.0807)  loss_mal_aux_0: 0.8687 (1.2048)  loss_bbox_aux_0: 0.2940 (0.4009)  loss_giou_aux_0: 0.2922 (0.3732)  loss_fgl_aux_0: 1.1582 (1.1651)  loss_ddf_aux_0: 0.0807 (0.1019)  loss_mal_aux_1: 0.7139 (1.0666)  loss_bbox_aux_1: 0.2573 (0.3430)  loss_giou_aux_1: 0.2618 (0.3200)  loss_fgl_aux_1: 1.0674 (1.0883)  loss_ddf_aux_1: 0.0061 (0.0065)  loss_mal_pre: 0.8633 (1.2021)  loss_bbox_pre: 0.2950 (0.4009)  loss_giou_pre: 0.2931 (0.3725)  loss_mal_enc_0: 1.0918 (1.6202)  loss_bbox_enc_0: 0.4545 (0.7120)  loss_giou_enc_0: 0.4112 (0.6028)  loss_mal_dn_0: 0.6724 (0.7250)  loss_bbox_dn_0: 0.4452 (0.5168)  loss_giou_dn_0: 0.4013 (0.4772)  loss_fgl_dn_0: 1.2222 (1.2432)  loss_ddf_dn_0: 0.2449 (0.2492)  loss_mal_dn_1: 0.5366 (0.6033)  loss_bbox_dn_1: 0.2646 (0.3714)  loss_giou_dn_1: 0.2792 (0.3352)  loss_fgl_dn_1: 1.0529 (1.1007)  loss_ddf_dn_1: 0.0171 (0.0173)  loss_mal_dn_2: 0.5137 (0.5847)  loss_bbox_dn_2: 0.2511 (0.3515)  loss_giou_dn_2: 0.2619 (0.3175)  loss_fgl_dn_2: 1.0378 (1.0871)  loss_mal_dn_pre: 0.6714 (0.7233)  loss_bbox_dn_pre: 0.4375 (0.5260)  loss_giou_dn_pre: 0.4001 (0.4773)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.29it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.660\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.878\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.782\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.234\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.388\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.694\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.690\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.801\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.849\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.680\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.873\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.986\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.963\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:45:01.554\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:45:01.556\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 0 / mAP: 0.6599056916833095\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:45:01.557\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 0, 'coco_eval_bbox': 0.6599056916833095}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:45:01.557\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 1/10\u001b[0m\n",
+      "Epoch 1: 100%|██████████| 403/403 [01:57<00:00,  3.43it/s, loss=19.1200]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 18.4611 (19.9031)  loss_mal: 0.6011 (0.7362)  loss_bbox: 0.2384 (0.2629)  loss_giou: 0.2375 (0.2568)  loss_fgl: 1.0249 (1.0565)  loss_mal_aux_0: 0.7710 (0.9142)  loss_bbox_aux_0: 0.2735 (0.3183)  loss_giou_aux_0: 0.3023 (0.3099)  loss_fgl_aux_0: 1.1258 (1.1582)  loss_ddf_aux_0: 0.1115 (0.1149)  loss_mal_aux_1: 0.6689 (0.7693)  loss_bbox_aux_1: 0.2375 (0.2666)  loss_giou_aux_1: 0.2390 (0.2604)  loss_fgl_aux_1: 1.0358 (1.0613)  loss_ddf_aux_1: 0.0048 (0.0071)  loss_mal_pre: 0.7681 (0.9139)  loss_bbox_pre: 0.2724 (0.3152)  loss_giou_pre: 0.3012 (0.3074)  loss_mal_enc_0: 0.9204 (1.0724)  loss_bbox_enc_0: 0.4173 (0.5245)  loss_giou_enc_0: 0.4052 (0.4714)  loss_mal_dn_0: 0.6519 (0.6824)  loss_bbox_dn_0: 0.3505 (0.4134)  loss_giou_dn_0: 0.3660 (0.4017)  loss_fgl_dn_0: 1.2008 (1.2262)  loss_ddf_dn_0: 0.3060 (0.2836)  loss_mal_dn_1: 0.4990 (0.5459)  loss_bbox_dn_1: 0.2286 (0.2790)  loss_giou_dn_1: 0.2427 (0.2718)  loss_fgl_dn_1: 1.0149 (1.0677)  loss_ddf_dn_1: 0.0160 (0.0194)  loss_mal_dn_2: 0.4871 (0.5325)  loss_bbox_dn_2: 0.2154 (0.2652)  loss_giou_dn_2: 0.2289 (0.2602)  loss_fgl_dn_2: 1.0055 (1.0540)  loss_mal_dn_pre: 0.6499 (0.6812)  loss_bbox_dn_pre: 0.3583 (0.4200)  loss_giou_dn_pre: 0.3693 (0.4016)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.31it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.680\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.882\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.780\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.294\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.525\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.705\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.727\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.831\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.856\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.726\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.876\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.952\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:47:04.336\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:47:04.337\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 1 / mAP: 0.6801175018433107\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:47:04.338\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 1, 'coco_eval_bbox': 0.6801175018433107}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:47:04.339\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 2/10\u001b[0m\n",
+      "Epoch 2: 100%|██████████| 403/403 [01:57<00:00,  3.42it/s, loss=15.3247]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 17.8616 (18.1320)  loss_mal: 0.5527 (0.6187)  loss_bbox: 0.1709 (0.2227)  loss_giou: 0.2161 (0.2254)  loss_fgl: 1.0176 (1.0155)  loss_mal_aux_0: 0.6777 (0.7815)  loss_bbox_aux_0: 0.2487 (0.2736)  loss_giou_aux_0: 0.2576 (0.2739)  loss_fgl_aux_0: 1.0864 (1.1225)  loss_ddf_aux_0: 0.0905 (0.1217)  loss_mal_aux_1: 0.5645 (0.6547)  loss_bbox_aux_1: 0.1732 (0.2256)  loss_giou_aux_1: 0.2221 (0.2284)  loss_fgl_aux_1: 1.0105 (1.0210)  loss_ddf_aux_1: 0.0053 (0.0068)  loss_mal_pre: 0.6772 (0.7809)  loss_bbox_pre: 0.2423 (0.2716)  loss_giou_pre: 0.2575 (0.2713)  loss_mal_enc_0: 0.8442 (0.9368)  loss_bbox_enc_0: 0.4348 (0.4504)  loss_giou_enc_0: 0.4176 (0.4199)  loss_mal_dn_0: 0.6270 (0.6465)  loss_bbox_dn_0: 0.3341 (0.3602)  loss_giou_dn_0: 0.3431 (0.3592)  loss_fgl_dn_0: 1.1872 (1.2097)  loss_ddf_dn_0: 0.2793 (0.3197)  loss_mal_dn_1: 0.4729 (0.4956)  loss_bbox_dn_1: 0.1960 (0.2324)  loss_giou_dn_1: 0.2198 (0.2341)  loss_fgl_dn_1: 1.0067 (1.0236)  loss_ddf_dn_1: 0.0159 (0.0194)  loss_mal_dn_2: 0.4602 (0.4810)  loss_bbox_dn_2: 0.1870 (0.2216)  loss_giou_dn_2: 0.2037 (0.2253)  loss_fgl_dn_2: 0.9912 (1.0100)  loss_mal_dn_pre: 0.6265 (0.6452)  loss_bbox_dn_pre: 0.3517 (0.3665)  loss_giou_dn_pre: 0.3394 (0.3592)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.37it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.704\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.903\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.814\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.332\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.444\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.735\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.725\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.841\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.863\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.696\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.886\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.961\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:49:07.417\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:49:07.418\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 2 / mAP: 0.7038531361893561\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:49:07.419\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 2, 'coco_eval_bbox': 0.7038531361893561}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:49:07.420\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 3/10\u001b[0m\n",
+      "Epoch 3: 100%|██████████| 403/403 [01:54<00:00,  3.51it/s, loss=14.6760]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 17.4232 (17.0955)  loss_mal: 0.5029 (0.5599)  loss_bbox: 0.1854 (0.1973)  loss_giou: 0.1975 (0.2048)  loss_fgl: 0.9595 (0.9879)  loss_mal_aux_0: 0.6416 (0.6960)  loss_bbox_aux_0: 0.2337 (0.2469)  loss_giou_aux_0: 0.2431 (0.2537)  loss_fgl_aux_0: 1.0666 (1.1029)  loss_ddf_aux_0: 0.1353 (0.1299)  loss_mal_aux_1: 0.5396 (0.5798)  loss_bbox_aux_1: 0.1878 (0.2004)  loss_giou_aux_1: 0.2017 (0.2080)  loss_fgl_aux_1: 0.9575 (0.9931)  loss_ddf_aux_1: 0.0054 (0.0074)  loss_mal_pre: 0.6455 (0.6947)  loss_bbox_pre: 0.2333 (0.2439)  loss_giou_pre: 0.2438 (0.2511)  loss_mal_enc_0: 0.8120 (0.8785)  loss_bbox_enc_0: 0.4850 (0.4150)  loss_giou_enc_0: 0.4074 (0.3923)  loss_mal_dn_0: 0.6187 (0.6260)  loss_bbox_dn_0: 0.3536 (0.3297)  loss_giou_dn_0: 0.3345 (0.3346)  loss_fgl_dn_0: 1.1830 (1.1972)  loss_ddf_dn_0: 0.3514 (0.3261)  loss_mal_dn_1: 0.4583 (0.4657)  loss_bbox_dn_1: 0.2041 (0.2078)  loss_giou_dn_1: 0.1997 (0.2138)  loss_fgl_dn_1: 0.9700 (0.9965)  loss_ddf_dn_1: 0.0179 (0.0195)  loss_mal_dn_2: 0.4595 (0.4526)  loss_bbox_dn_2: 0.1927 (0.1977)  loss_giou_dn_2: 0.1922 (0.2054)  loss_fgl_dn_2: 0.9533 (0.9829)  loss_mal_dn_pre: 0.6187 (0.6250)  loss_bbox_dn_pre: 0.3649 (0.3365)  loss_giou_dn_pre: 0.3386 (0.3350)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.35it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.718\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.915\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.831\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.325\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.513\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.744\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.737\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.844\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.867\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.708\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.889\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.961\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:51:07.569\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:51:07.570\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 3 / mAP: 0.7182062553530311\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:51:07.571\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 3, 'coco_eval_bbox': 0.7182062553530311}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:51:07.572\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 4/10\u001b[0m\n",
+      "Epoch 4: 100%|██████████| 403/403 [02:35<00:00,  2.59it/s, loss=23.8774]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 20.0275 (22.3579)  loss_mal: 0.8862 (0.9299)  loss_bbox: 0.2267 (0.3301)  loss_giou: 0.3892 (0.4599)  loss_fgl: 1.1033 (1.1067)  loss_mal_aux_0: 0.9331 (0.9953)  loss_bbox_aux_0: 0.2578 (0.3481)  loss_giou_aux_0: 0.4091 (0.4932)  loss_fgl_aux_0: 1.1408 (1.1499)  loss_ddf_aux_0: 0.0876 (0.0908)  loss_mal_aux_1: 0.8940 (0.9451)  loss_bbox_aux_1: 0.2311 (0.3309)  loss_giou_aux_1: 0.3863 (0.4615)  loss_fgl_aux_1: 1.1061 (1.1078)  loss_ddf_aux_1: 0.0039 (0.0041)  loss_mal_pre: 0.9312 (0.9949)  loss_bbox_pre: 0.2596 (0.3468)  loss_giou_pre: 0.4092 (0.4920)  loss_mal_enc_0: 0.9854 (1.0455)  loss_bbox_enc_0: 0.3995 (0.4300)  loss_giou_enc_0: 0.5834 (0.6104)  loss_mal_dn_0: 0.6963 (0.7267)  loss_bbox_dn_0: 0.2760 (0.3639)  loss_giou_dn_0: 0.4538 (0.5360)  loss_fgl_dn_0: 1.1855 (1.1976)  loss_ddf_dn_0: 0.2357 (0.2651)  loss_mal_dn_1: 0.5977 (0.6474)  loss_bbox_dn_1: 0.2127 (0.3086)  loss_giou_dn_1: 0.3395 (0.4265)  loss_fgl_dn_1: 1.1079 (1.1056)  loss_ddf_dn_1: 0.0108 (0.0124)  loss_mal_dn_2: 0.5903 (0.6408)  loss_bbox_dn_2: 0.2135 (0.3052)  loss_giou_dn_2: 0.3404 (0.4199)  loss_fgl_dn_2: 1.1011 (1.1021)  loss_mal_dn_pre: 0.6948 (0.7266)  loss_bbox_dn_pre: 0.2793 (0.3644)  loss_giou_dn_pre: 0.4519 (0.5361)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.04it/s]\n",
+      "\u001b[32m2025-04-03 15:53:48.364\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 3, 'coco_eval_bbox': 0.7182062553530311}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:53:48.364\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 5/10\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.706\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.909\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.836\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.363\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.413\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.738\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.724\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.811\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.850\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.622\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.877\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.982\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.956\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 5: 100%|██████████| 403/403 [02:34<00:00,  2.60it/s, loss=17.6145]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000185  loss: 18.9472 (21.2556)  loss_mal: 0.7690 (0.8563)  loss_bbox: 0.2489 (0.2939)  loss_giou: 0.3655 (0.4252)  loss_fgl: 1.0629 (1.0913)  loss_mal_aux_0: 0.8657 (0.9385)  loss_bbox_aux_0: 0.2662 (0.3102)  loss_giou_aux_0: 0.4119 (0.4561)  loss_fgl_aux_0: 1.1036 (1.1393)  loss_ddf_aux_0: 0.0703 (0.0910)  loss_mal_aux_1: 0.7832 (0.8768)  loss_bbox_aux_1: 0.2503 (0.2948)  loss_giou_aux_1: 0.3704 (0.4268)  loss_fgl_aux_1: 1.0650 (1.0930)  loss_ddf_aux_1: 0.0034 (0.0040)  loss_mal_pre: 0.8628 (0.9369)  loss_bbox_pre: 0.2679 (0.3091)  loss_giou_pre: 0.4136 (0.4548)  loss_mal_enc_0: 0.9419 (1.0101)  loss_bbox_enc_0: 0.3530 (0.3987)  loss_giou_enc_0: 0.5149 (0.5806)  loss_mal_dn_0: 0.6880 (0.7078)  loss_bbox_dn_0: 0.2601 (0.3314)  loss_giou_dn_0: 0.4246 (0.4976)  loss_fgl_dn_0: 1.1753 (1.1921)  loss_ddf_dn_0: 0.2131 (0.2607)  loss_mal_dn_1: 0.5728 (0.6180)  loss_bbox_dn_1: 0.2125 (0.2783)  loss_giou_dn_1: 0.3291 (0.3931)  loss_fgl_dn_1: 1.0823 (1.0874)  loss_ddf_dn_1: 0.0102 (0.0112)  loss_mal_dn_2: 0.5635 (0.6088)  loss_bbox_dn_2: 0.2134 (0.2747)  loss_giou_dn_2: 0.3268 (0.3868)  loss_fgl_dn_2: 1.0764 (1.0830)  loss_mal_dn_pre: 0.6851 (0.7074)  loss_bbox_dn_pre: 0.2621 (0.3326)  loss_giou_dn_pre: 0.4259 (0.4976)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.02it/s]\n",
+      "\u001b[32m2025-04-03 15:56:28.387\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 3, 'coco_eval_bbox': 0.7182062553530311}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:56:28.387\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 6/10\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.716\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.918\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.850\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.347\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.495\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.745\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.724\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.812\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.851\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.619\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.877\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.980\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.952\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 6: 100%|██████████| 403/403 [02:34<00:00,  2.60it/s, loss=22.2682]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000150  loss: 21.0575 (20.4349)  loss_mal: 0.8735 (0.8097)  loss_bbox: 0.2839 (0.2682)  loss_giou: 0.4068 (0.3962)  loss_fgl: 1.0615 (1.0834)  loss_mal_aux_0: 0.9595 (0.8919)  loss_bbox_aux_0: 0.3041 (0.2841)  loss_giou_aux_0: 0.4463 (0.4254)  loss_fgl_aux_0: 1.1155 (1.1321)  loss_ddf_aux_0: 0.0905 (0.0908)  loss_mal_aux_1: 0.9038 (0.8258)  loss_bbox_aux_1: 0.2828 (0.2690)  loss_giou_aux_1: 0.4077 (0.3980)  loss_fgl_aux_1: 1.0647 (1.0850)  loss_ddf_aux_1: 0.0035 (0.0039)  loss_mal_pre: 0.9487 (0.8901)  loss_bbox_pre: 0.3014 (0.2830)  loss_giou_pre: 0.4451 (0.4242)  loss_mal_enc_0: 1.0283 (0.9719)  loss_bbox_enc_0: 0.4179 (0.3728)  loss_giou_enc_0: 0.6022 (0.5514)  loss_mal_dn_0: 0.7192 (0.6924)  loss_bbox_dn_0: 0.3250 (0.3083)  loss_giou_dn_0: 0.4619 (0.4714)  loss_fgl_dn_0: 1.1878 (1.1892)  loss_ddf_dn_0: 0.2551 (0.2584)  loss_mal_dn_1: 0.6421 (0.5962)  loss_bbox_dn_1: 0.2637 (0.2554)  loss_giou_dn_1: 0.3499 (0.3703)  loss_fgl_dn_1: 1.0688 (1.0768)  loss_ddf_dn_1: 0.0098 (0.0102)  loss_mal_dn_2: 0.6274 (0.5873)  loss_bbox_dn_2: 0.2618 (0.2521)  loss_giou_dn_2: 0.3422 (0.3646)  loss_fgl_dn_2: 1.0635 (1.0727)  loss_mal_dn_pre: 0.7192 (0.6919)  loss_bbox_dn_pre: 0.3289 (0.3096)  loss_giou_dn_pre: 0.4547 (0.4712)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.23it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.719\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.920\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.822\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.335\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.518\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.746\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.735\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.818\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.859\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.623\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.885\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.982\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.953\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 15:59:08.706\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:59:08.708\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 6 / mAP: 0.7190669101349528\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:59:08.709\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 6, 'coco_eval_bbox': 0.7190669101349528}\u001b[0m\n",
+      "\u001b[32m2025-04-03 15:59:08.710\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 7/10\u001b[0m\n",
+      "Epoch 7: 100%|██████████| 403/403 [02:36<00:00,  2.58it/s, loss=23.4055]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000115  loss: 20.2361 (20.1228)  loss_mal: 0.8008 (0.7892)  loss_bbox: 0.2647 (0.2658)  loss_giou: 0.4001 (0.3887)  loss_fgl: 1.0558 (1.0767)  loss_mal_aux_0: 0.8975 (0.8712)  loss_bbox_aux_0: 0.2766 (0.2812)  loss_giou_aux_0: 0.4274 (0.4151)  loss_fgl_aux_0: 1.1031 (1.1235)  loss_ddf_aux_0: 0.0818 (0.0863)  loss_mal_aux_1: 0.8052 (0.8059)  loss_bbox_aux_1: 0.2674 (0.2668)  loss_giou_aux_1: 0.4052 (0.3903)  loss_fgl_aux_1: 1.0564 (1.0783)  loss_ddf_aux_1: 0.0032 (0.0036)  loss_mal_pre: 0.8931 (0.8700)  loss_bbox_pre: 0.2730 (0.2805)  loss_giou_pre: 0.4323 (0.4141)  loss_mal_enc_0: 0.9561 (0.9624)  loss_bbox_enc_0: 0.3377 (0.3656)  loss_giou_enc_0: 0.5246 (0.5367)  loss_mal_dn_0: 0.6943 (0.6831)  loss_bbox_dn_0: 0.2517 (0.3051)  loss_giou_dn_0: 0.4815 (0.4547)  loss_fgl_dn_0: 1.1762 (1.1828)  loss_ddf_dn_0: 0.2161 (0.2458)  loss_mal_dn_1: 0.6187 (0.5873)  loss_bbox_dn_1: 0.2016 (0.2539)  loss_giou_dn_1: 0.3903 (0.3611)  loss_fgl_dn_1: 1.0757 (1.0716)  loss_ddf_dn_1: 0.0077 (0.0092)  loss_mal_dn_2: 0.6133 (0.5788)  loss_bbox_dn_2: 0.1989 (0.2505)  loss_giou_dn_2: 0.3844 (0.3557)  loss_fgl_dn_2: 1.0682 (1.0675)  loss_mal_dn_pre: 0.6938 (0.6826)  loss_bbox_dn_pre: 0.2584 (0.3067)  loss_giou_dn_pre: 0.4842 (0.4546)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.04it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.735\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.937\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.850\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.506\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.762\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.738\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.820\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.849\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.673\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.871\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.950\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 16:01:50.201\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 16:01:50.203\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 7 / mAP: 0.7350911486055055\u001b[0m\n",
+      "\u001b[32m2025-04-03 16:01:50.204\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 7, 'coco_eval_bbox': 0.7350911486055055}\u001b[0m\n",
+      "\u001b[32m2025-04-03 16:01:50.204\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 8/10\u001b[0m\n",
+      "Epoch 8: 100%|██████████| 403/403 [02:33<00:00,  2.62it/s, loss=16.2427]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 19.9205 (19.2629)  loss_mal: 0.7905 (0.7448)  loss_bbox: 0.1961 (0.2444)  loss_giou: 0.3287 (0.3589)  loss_fgl: 1.0644 (1.0600)  loss_mal_aux_0: 0.8257 (0.8256)  loss_bbox_aux_0: 0.2425 (0.2587)  loss_giou_aux_0: 0.3555 (0.3835)  loss_fgl_aux_0: 1.1130 (1.1090)  loss_ddf_aux_0: 0.0916 (0.0881)  loss_mal_aux_1: 0.8164 (0.7614)  loss_bbox_aux_1: 0.2012 (0.2452)  loss_giou_aux_1: 0.3318 (0.3600)  loss_fgl_aux_1: 1.0680 (1.0620)  loss_ddf_aux_1: 0.0037 (0.0034)  loss_mal_pre: 0.8311 (0.8251)  loss_bbox_pre: 0.2389 (0.2583)  loss_giou_pre: 0.3543 (0.3827)  loss_mal_enc_0: 0.9253 (0.9265)  loss_bbox_enc_0: 0.3326 (0.3407)  loss_giou_enc_0: 0.4971 (0.5021)  loss_mal_dn_0: 0.6675 (0.6646)  loss_bbox_dn_0: 0.2632 (0.2824)  loss_giou_dn_0: 0.3953 (0.4239)  loss_fgl_dn_0: 1.1694 (1.1730)  loss_ddf_dn_0: 0.2612 (0.2520)  loss_mal_dn_1: 0.5801 (0.5619)  loss_bbox_dn_1: 0.2078 (0.2336)  loss_giou_dn_1: 0.3096 (0.3348)  loss_fgl_dn_1: 1.0699 (1.0528)  loss_ddf_dn_1: 0.0090 (0.0083)  loss_mal_dn_2: 0.5928 (0.5530)  loss_bbox_dn_2: 0.2069 (0.2306)  loss_giou_dn_2: 0.3040 (0.3303)  loss_fgl_dn_2: 1.0677 (1.0488)  loss_mal_dn_pre: 0.6680 (0.6642)  loss_bbox_dn_pre: 0.2641 (0.2843)  loss_giou_dn_pre: 0.3974 (0.4240)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.06it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.744\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.941\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.853\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.335\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.530\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.771\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.747\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.830\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.852\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.666\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.877\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.945\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 16:04:29.429\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 16:04:29.430\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 8 / mAP: 0.7440468222262839\u001b[0m\n",
+      "\u001b[32m2025-04-03 16:04:29.431\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 8, 'coco_eval_bbox': 0.7440468222262839}\u001b[0m\n",
+      "\u001b[32m2025-04-03 16:04:29.433\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 9/10\u001b[0m\n",
+      "Epoch 9: 100%|██████████| 403/403 [02:34<00:00,  2.61it/s, loss=15.0710]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 18.0015 (19.3772)  loss_mal: 0.6836 (0.7481)  loss_bbox: 0.2294 (0.2521)  loss_giou: 0.3392 (0.3690)  loss_fgl: 1.0270 (1.0593)  loss_mal_aux_0: 0.7446 (0.8272)  loss_bbox_aux_0: 0.2343 (0.2658)  loss_giou_aux_0: 0.3609 (0.3942)  loss_fgl_aux_0: 1.0766 (1.1074)  loss_ddf_aux_0: 0.0873 (0.0844)  loss_mal_aux_1: 0.7148 (0.7646)  loss_bbox_aux_1: 0.2285 (0.2529)  loss_giou_aux_1: 0.3368 (0.3703)  loss_fgl_aux_1: 1.0282 (1.0611)  loss_ddf_aux_1: 0.0032 (0.0032)  loss_mal_pre: 0.7617 (0.8269)  loss_bbox_pre: 0.2347 (0.2652)  loss_giou_pre: 0.3624 (0.3933)  loss_mal_enc_0: 0.8745 (0.9234)  loss_bbox_enc_0: 0.3331 (0.3472)  loss_giou_enc_0: 0.5202 (0.5170)  loss_mal_dn_0: 0.6416 (0.6655)  loss_bbox_dn_0: 0.2656 (0.2835)  loss_giou_dn_0: 0.3865 (0.4278)  loss_fgl_dn_0: 1.1573 (1.1698)  loss_ddf_dn_0: 0.2656 (0.2478)  loss_mal_dn_1: 0.5532 (0.5654)  loss_bbox_dn_1: 0.2124 (0.2354)  loss_giou_dn_1: 0.2858 (0.3394)  loss_fgl_dn_1: 1.0450 (1.0520)  loss_ddf_dn_1: 0.0077 (0.0079)  loss_mal_dn_2: 0.5415 (0.5568)  loss_bbox_dn_2: 0.2126 (0.2325)  loss_giou_dn_2: 0.2853 (0.3348)  loss_fgl_dn_2: 1.0386 (1.0483)  loss_mal_dn_pre: 0.6406 (0.6651)  loss_bbox_dn_pre: 0.2626 (0.2849)  loss_giou_dn_pre: 0.3779 (0.4278)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.25it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.747\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.943\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.854\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.313\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.535\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.773\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.751\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.832\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.858\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.698\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.879\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.950\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 16:07:08.968\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 16:07:08.971\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 9 / mAP: 0.746591104942225\u001b[0m\n",
+      "\u001b[32m2025-04-03 16:07:08.973\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 9, 'coco_eval_bbox': 0.746591104942225}\u001b[0m\n",
+      "\u001b[32m2025-04-03 16:07:08.974\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m555\u001b[0m - \u001b[1mTraining completed in 0:24:08\u001b[0m\n",
+      "\u001b[32m2025-04-03 16:07:08.974\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m556\u001b[0m - \u001b[1mBest stats: {'epoch': 9, 'coco_eval_bbox': 0.746591104942225}\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "from deimkit import Config, Trainer, configure_dataset, configure_model\n",
+    "\n",
+    "conf = Config.from_model_name(\"deim_hgnetv2_s\")\n",
+    "\n",
+    "conf = configure_model(conf, num_queries=100, freeze_at=0, pretrained=True)\n",
+    "\n",
+    "conf = configure_dataset(\n",
+    "    config=conf,\n",
+    "    image_size=(640, 640),\n",
+    "    train_ann_file=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train/_annotations.coco.json\",\n",
+    "    train_img_folder=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train\",\n",
+    "    val_ann_file=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid/_annotations.coco.json\",\n",
+    "    val_img_folder=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid\",\n",
+    "    train_batch_size=16,\n",
+    "    val_batch_size=16,\n",
+    "    num_classes=4,\n",
+    "    remap_mscoco=False,\n",
+    "    output_dir=\"./outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_640px_freeze_at_0\",\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(conf)\n",
+    "\n",
+    "trainer.load_checkpoint(\"./outputs/rock-paper-scissors/deim_hgnetv2_s_10ep_320px/best.pth\")\n",
+    "trainer.fit(epochs=10, save_best_only=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.2.0'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import deimkit\n",
+    "\n",
+    "deimkit.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "cuda",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/nbs/progressive-resising.ipynb
+++ b/nbs/progressive-resising.ipynb
@@ -2587,6 +2587,1703 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:11:59.683\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.DFINETransformer.num_queries' to: 100\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.684\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.PostProcessor.num_top_queries' to: 100\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.684\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.HGNetv2.pretrained' to: True\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.684\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.model\u001b[0m:\u001b[36mupdate_setting\u001b[0m:\u001b[36m83\u001b[0m - \u001b[1mSetting 'yaml_cfg.HGNetv2.freeze_at' to: 0\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.684\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_init_process_group\u001b[0m:\u001b[36m60\u001b[0m - \u001b[1mInitializing process group for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.699\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m239\u001b[0m - \u001b[1mStarting training...\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.700\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m242\u001b[0m - \u001b[1mOverriding epochs to 30\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.700\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m276\u001b[0m - \u001b[1mSetting pretrained flag to True for HGNetv2\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.701\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m296\u001b[0m - \u001b[1mAutomatically calculated mixup epochs: [1, 15]\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.701\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m306\u001b[0m - \u001b[1mAutomatically calculated data augmentation epochs: 1, 15, 27\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.701\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m315\u001b[0m - \u001b[1mAutomatically calculated stop epoch: 27\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.701\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m323\u001b[0m - \u001b[1mAutomatically calculated no augmentation epochs: 3\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.702\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m336\u001b[0m - \u001b[1mAutomatically calculated flat epochs: 15\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.705\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m363\u001b[0m - \u001b[1mAutomatically calculated warmup iterations: 605 (1.5 epochs)\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.705\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m376\u001b[0m - \u001b[1mAutomatically calculated EMA warmups: 605 (1.5 epochs)\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.705\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m152\u001b[0m - \u001b[1mDisabling sync_bn and find_unused_parameters for single-process training\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.706\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m164\u001b[0m - \u001b[1mSet device in config: cuda\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:11:59.706\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m174\u001b[0m - \u001b[1mInitializing solver for task: detection\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded stage1 B0 HGNetV2 from local file.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/dnth/Desktop/DEIMKit/src/deimkit/engine/core/workspace.py:180: FutureWarning: `torch.cuda.amp.GradScaler(args...)` is deprecated. Please use `torch.amp.GradScaler('cuda', args...)` instead.\n",
+      "  return module(**module_kwargs)\n",
+      "\u001b[32m2025-04-03 17:12:00.130\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m201\u001b[0m - \u001b[1mTraining setup complete. Output directory: outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:12:00.131\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_setup\u001b[0m:\u001b[36m203\u001b[0m - \u001b[1mSaving config to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/config.yml\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:12:00.137\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m384\u001b[0m - \u001b[1mUsing device: cuda\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial lr: [0.0002, 0.0004, 0.0004]\n",
+      "building train_dataloader with batch_size=16...\n",
+      "     ### Transform @Mosaic ###    \n",
+      "     ### Transform @RandomPhotometricDistort ###    \n",
+      "     ### Transform @RandomZoomOut ###    \n",
+      "     ### Transform @RandomIoUCrop ###    \n",
+      "     ### Transform @SanitizeBoundingBoxes ###    \n",
+      "     ### Transform @RandomHorizontalFlip ###    \n",
+      "     ### Transform @Resize ###    \n",
+      "     ### Transform @SanitizeBoundingBoxes ###    \n",
+      "     ### Transform @ConvertPILImage ###    \n",
+      "     ### Transform @ConvertBoxes ###    \n",
+      "     ### Mosaic with Prob.@0.5 and ZoomOut/IoUCrop existed ### \n",
+      "     ### ImgTransforms Epochs: [1, 15, 27] ### \n",
+      "     ### Policy_ops@['Mosaic', 'RandomPhotometricDistort', 'RandomZoomOut', 'RandomIoUCrop'] ###\n",
+      "     ### Using MixUp with Prob@0.5 in [1, 15] epochs ### \n",
+      "     ### Multi-scale Training until 27 epochs ### \n",
+      "     ### Multi-scales@ [480, 512, 544, 576, 608, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 640, 800, 768, 736, 704, 672] ###        \n",
+      "building val_dataloader with batch_size=16...\n",
+      "     ### Transform @Resize ###    \n",
+      "     ### Transform @ConvertPILImage ###    \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:12:00.267\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:12:00.268\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m393\u001b[0m - \u001b[1mInitial model saved as best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:12:00.271\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m403\u001b[0m - \u001b[1mNumber of trainable parameters: 10217817\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:12:00.271\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m409\u001b[0m - \u001b[1mUsing custom scheduler: flatcosine\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:12:00.272\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 0/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.0002, 0.0004, 0.0004] [0.0001, 0.0002, 0.0002] 12090 605 6045 1209\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: 100%|██████████| 403/403 [01:58<00:00,  3.41it/s, loss=29.0743]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000088  loss: 31.9983 (38.9885)  loss_mal: 1.6484 (1.1314)  loss_bbox: 0.5540 (1.6050)  loss_giou: 0.5321 (1.1803)  loss_fgl: 1.2765 (0.8584)  loss_mal_aux_0: 1.5410 (1.0430)  loss_bbox_aux_0: 0.5639 (1.6447)  loss_giou_aux_0: 0.5480 (1.2072)  loss_fgl_aux_0: 1.2829 (0.8743)  loss_mal_aux_1: 1.5713 (1.0898)  loss_bbox_aux_1: 0.5494 (1.6177)  loss_giou_aux_1: 0.5318 (1.1903)  loss_fgl_aux_1: 1.2635 (0.8621)  loss_mal_pre: 1.5771 (1.0297)  loss_bbox_pre: 0.5616 (1.6552)  loss_giou_pre: 0.5459 (1.2124)  loss_mal_enc_0: 1.2061 (0.9628)  loss_bbox_enc_0: 0.9767 (1.7918)  loss_giou_enc_0: 0.8568 (1.3093)  loss_mal_dn_0: 0.8237 (0.8335)  loss_bbox_dn_0: 0.9733 (1.4357)  loss_giou_dn_0: 0.8432 (1.2239)  loss_fgl_dn_0: 1.1614 (0.9205)  loss_mal_dn_1: 0.7793 (0.8652)  loss_bbox_dn_1: 0.9112 (1.4087)  loss_giou_dn_1: 0.8032 (1.2100)  loss_fgl_dn_1: 1.1819 (0.9193)  loss_mal_dn_2: 0.8057 (0.8370)  loss_bbox_dn_2: 0.8336 (1.3887)  loss_giou_dn_2: 0.7301 (1.1939)  loss_fgl_dn_2: 1.1946 (0.9240)  loss_mal_dn_pre: 0.8193 (0.8328)  loss_bbox_dn_pre: 1.0042 (1.4552)  loss_giou_dn_pre: 0.8440 (1.2266)  loss_ddf_aux_0: 0.0792 (0.0223)  loss_ddf_aux_1: 0.0123 (0.0035)  loss_ddf_dn_0: 0.0634 (0.0191)  loss_ddf_dn_1: 0.0195 (0.0040)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.04it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.143\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.262\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.135\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.095\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.156\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.443\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.598\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.643\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.685\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.959\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.744\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:14:03.906\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:14:03.908\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 0 / mAP: 0.14268729653584372\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:14:03.909\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 0, 'coco_eval_bbox': 0.14268729653584372}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:14:03.909\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 1/30\u001b[0m\n",
+      "Epoch 1: 100%|██████████| 403/403 [02:44<00:00,  2.45it/s, loss=29.0779]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 25.8008 (28.8962)  loss_mal: 1.1182 (1.3002)  loss_bbox: 0.3414 (0.5084)  loss_giou: 0.5570 (0.7271)  loss_fgl: 1.1811 (1.1576)  loss_mal_aux_0: 1.1377 (1.2537)  loss_bbox_aux_0: 0.3838 (0.5276)  loss_giou_aux_0: 0.6202 (0.7627)  loss_fgl_aux_0: 1.2032 (1.1530)  loss_ddf_aux_0: 0.0575 (0.0593)  loss_mal_aux_1: 1.1504 (1.2812)  loss_bbox_aux_1: 0.3417 (0.5098)  loss_giou_aux_1: 0.5635 (0.7329)  loss_fgl_aux_1: 1.1844 (1.1553)  loss_ddf_aux_1: 0.0045 (0.0095)  loss_mal_pre: 1.1318 (1.2502)  loss_bbox_pre: 0.3817 (0.5249)  loss_giou_pre: 0.6052 (0.7613)  loss_mal_enc_0: 1.1846 (1.1837)  loss_bbox_enc_0: 0.5082 (0.6613)  loss_giou_enc_0: 0.7759 (0.9187)  loss_mal_dn_0: 0.7871 (0.7874)  loss_bbox_dn_0: 0.4855 (0.6212)  loss_giou_dn_0: 0.7680 (0.9065)  loss_fgl_dn_0: 1.1791 (1.1071)  loss_ddf_dn_0: 0.2185 (0.1303)  loss_mal_dn_1: 0.8057 (0.8028)  loss_bbox_dn_1: 0.3913 (0.5659)  loss_giou_dn_1: 0.6038 (0.8178)  loss_fgl_dn_1: 1.1682 (1.1187)  loss_ddf_dn_1: 0.0222 (0.0205)  loss_mal_dn_2: 0.7959 (0.7978)  loss_bbox_dn_2: 0.3815 (0.5516)  loss_giou_dn_2: 0.5820 (0.7907)  loss_fgl_dn_2: 1.1755 (1.1249)  loss_mal_dn_pre: 0.7876 (0.7861)  loss_bbox_dn_pre: 0.4880 (0.6216)  loss_giou_dn_pre: 0.7595 (0.9070)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.22it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.319\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.554\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.365\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.245\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.183\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.340\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.533\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.695\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.747\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.263\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.490\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.774\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.975\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.904\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:16:53.953\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:16:53.954\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 1 / mAP: 0.3189018164374572\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:16:53.956\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 1, 'coco_eval_bbox': 0.3189018164374572}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:16:53.957\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 2/30\u001b[0m\n",
+      "Epoch 2: 100%|██████████| 403/403 [02:40<00:00,  2.52it/s, loss=20.4810]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 24.8105 (26.0452)  loss_mal: 1.0352 (1.1056)  loss_bbox: 0.3530 (0.4002)  loss_giou: 0.5345 (0.5733)  loss_fgl: 1.1555 (1.1812)  loss_mal_aux_0: 1.0664 (1.0939)  loss_bbox_aux_0: 0.3875 (0.4283)  loss_giou_aux_0: 0.5672 (0.6237)  loss_fgl_aux_0: 1.1768 (1.1918)  loss_ddf_aux_0: 0.0900 (0.0872)  loss_mal_aux_1: 1.0537 (1.1142)  loss_bbox_aux_1: 0.3554 (0.4015)  loss_giou_aux_1: 0.5369 (0.5768)  loss_fgl_aux_1: 1.1578 (1.1823)  loss_ddf_aux_1: 0.0063 (0.0063)  loss_mal_pre: 1.0635 (1.0907)  loss_bbox_pre: 0.3886 (0.4272)  loss_giou_pre: 0.5692 (0.6235)  loss_mal_enc_0: 1.0947 (1.1336)  loss_bbox_enc_0: 0.4877 (0.5441)  loss_giou_enc_0: 0.7204 (0.7710)  loss_mal_dn_0: 0.7749 (0.7880)  loss_bbox_dn_0: 0.4697 (0.5003)  loss_giou_dn_0: 0.6441 (0.7392)  loss_fgl_dn_0: 1.1965 (1.1837)  loss_ddf_dn_0: 0.3224 (0.2984)  loss_mal_dn_1: 0.7573 (0.7884)  loss_bbox_dn_1: 0.3819 (0.4200)  loss_giou_dn_1: 0.4988 (0.6005)  loss_fgl_dn_1: 1.1726 (1.1744)  loss_ddf_dn_1: 0.0262 (0.0271)  loss_mal_dn_2: 0.7397 (0.7779)  loss_bbox_dn_2: 0.3742 (0.4089)  loss_giou_dn_2: 0.4774 (0.5786)  loss_fgl_dn_2: 1.1620 (1.1737)  loss_mal_dn_pre: 0.7744 (0.7870)  loss_bbox_dn_pre: 0.4723 (0.5027)  loss_giou_dn_pre: 0.6530 (0.7402)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.89it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.571\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.789\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.713\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.301\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.424\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.594\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.679\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.782\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.811\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.325\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.663\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.834\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.981\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.956\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:19:39.793\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:19:39.794\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 2 / mAP: 0.5706173892308432\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:19:39.796\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 2, 'coco_eval_bbox': 0.5706173892308432}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:19:39.796\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 3/30\u001b[0m\n",
+      "Epoch 3: 100%|██████████| 403/403 [02:39<00:00,  2.53it/s, loss=21.0828]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 24.6327 (24.4214)  loss_mal: 0.9658 (1.0058)  loss_bbox: 0.3557 (0.3423)  loss_giou: 0.5329 (0.5096)  loss_fgl: 1.1281 (1.1650)  loss_mal_aux_0: 1.0176 (1.0243)  loss_bbox_aux_0: 0.3919 (0.3699)  loss_giou_aux_0: 0.5733 (0.5593)  loss_fgl_aux_0: 1.1563 (1.1911)  loss_ddf_aux_0: 0.1052 (0.1091)  loss_mal_aux_1: 0.9795 (1.0173)  loss_bbox_aux_1: 0.3610 (0.3432)  loss_giou_aux_1: 0.5342 (0.5123)  loss_fgl_aux_1: 1.1285 (1.1681)  loss_ddf_aux_1: 0.0067 (0.0073)  loss_mal_pre: 1.0117 (1.0224)  loss_bbox_pre: 0.3945 (0.3692)  loss_giou_pre: 0.5752 (0.5587)  loss_mal_enc_0: 1.0557 (1.0849)  loss_bbox_enc_0: 0.5133 (0.4887)  loss_giou_enc_0: 0.7241 (0.7211)  loss_mal_dn_0: 0.7617 (0.7726)  loss_bbox_dn_0: 0.4144 (0.4321)  loss_giou_dn_0: 0.6493 (0.6650)  loss_fgl_dn_0: 1.1992 (1.2040)  loss_ddf_dn_0: 0.3444 (0.3656)  loss_mal_dn_1: 0.7280 (0.7395)  loss_bbox_dn_1: 0.3353 (0.3547)  loss_giou_dn_1: 0.5234 (0.5197)  loss_fgl_dn_1: 1.1388 (1.1648)  loss_ddf_dn_1: 0.0253 (0.0278)  loss_mal_dn_2: 0.7222 (0.7267)  loss_bbox_dn_2: 0.3019 (0.3453)  loss_giou_dn_2: 0.5060 (0.5014)  loss_fgl_dn_2: 1.1289 (1.1601)  loss_mal_dn_pre: 0.7617 (0.7720)  loss_bbox_dn_pre: 0.4177 (0.4344)  loss_giou_dn_pre: 0.6687 (0.6657)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.02it/s]\n",
+      "\u001b[32m2025-04-03 17:22:24.446\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 2, 'coco_eval_bbox': 0.5706173892308432}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:22:24.446\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 4/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.546\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.797\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.656\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.320\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.375\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.569\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.641\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.769\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.805\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.615\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.828\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.980\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.944\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 4: 100%|██████████| 403/403 [02:38<00:00,  2.55it/s, loss=18.3548]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 22.3052 (23.7808)  loss_mal: 0.8994 (0.9731)  loss_bbox: 0.2625 (0.3306)  loss_giou: 0.4125 (0.4847)  loss_fgl: 1.1421 (1.1542)  loss_mal_aux_0: 0.9453 (1.0011)  loss_bbox_aux_0: 0.2966 (0.3579)  loss_giou_aux_0: 0.4548 (0.5321)  loss_fgl_aux_0: 1.1942 (1.1871)  loss_ddf_aux_0: 0.1077 (0.1159)  loss_mal_aux_1: 0.9004 (0.9861)  loss_bbox_aux_1: 0.2701 (0.3320)  loss_giou_aux_1: 0.4149 (0.4876)  loss_fgl_aux_1: 1.1424 (1.1565)  loss_ddf_aux_1: 0.0066 (0.0074)  loss_mal_pre: 0.9453 (0.9985)  loss_bbox_pre: 0.2965 (0.3566)  loss_giou_pre: 0.4454 (0.5305)  loss_mal_enc_0: 1.0215 (1.0678)  loss_bbox_enc_0: 0.3801 (0.4671)  loss_giou_enc_0: 0.6014 (0.6847)  loss_mal_dn_0: 0.7505 (0.7611)  loss_bbox_dn_0: 0.3225 (0.4127)  loss_giou_dn_0: 0.5464 (0.6281)  loss_fgl_dn_0: 1.2276 (1.2094)  loss_ddf_dn_0: 0.3985 (0.3895)  loss_mal_dn_1: 0.6763 (0.7153)  loss_bbox_dn_1: 0.2485 (0.3371)  loss_giou_dn_1: 0.4011 (0.4851)  loss_fgl_dn_1: 1.1396 (1.1521)  loss_ddf_dn_1: 0.0245 (0.0262)  loss_mal_dn_2: 0.6675 (0.7033)  loss_bbox_dn_2: 0.2407 (0.3286)  loss_giou_dn_2: 0.3864 (0.4693)  loss_fgl_dn_2: 1.1384 (1.1472)  loss_mal_dn_pre: 0.7495 (0.7609)  loss_bbox_dn_pre: 0.3284 (0.4143)  loss_giou_dn_pre: 0.5534 (0.6289)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.73it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.653\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.883\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.810\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.347\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.422\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.677\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.714\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.811\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.838\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.631\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.862\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.986\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.960\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:25:08.428\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:25:08.430\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 4 / mAP: 0.6525762497634597\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:25:08.431\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 4, 'coco_eval_bbox': 0.6525762497634597}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:25:08.432\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 5/30\u001b[0m\n",
+      "Epoch 5: 100%|██████████| 403/403 [02:38<00:00,  2.54it/s, loss=23.5950]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 22.5831 (22.8925)  loss_mal: 0.9233 (0.9060)  loss_bbox: 0.2985 (0.3099)  loss_giou: 0.4208 (0.4632)  loss_fgl: 1.1327 (1.1379)  loss_mal_aux_0: 0.9570 (0.9444)  loss_bbox_aux_0: 0.3196 (0.3364)  loss_giou_aux_0: 0.4702 (0.5088)  loss_fgl_aux_0: 1.1739 (1.1764)  loss_ddf_aux_0: 0.1184 (0.1150)  loss_mal_aux_1: 0.9468 (0.9227)  loss_bbox_aux_1: 0.2997 (0.3116)  loss_giou_aux_1: 0.4263 (0.4662)  loss_fgl_aux_1: 1.1389 (1.1404)  loss_ddf_aux_1: 0.0065 (0.0070)  loss_mal_pre: 0.9551 (0.9414)  loss_bbox_pre: 0.3225 (0.3352)  loss_giou_pre: 0.4720 (0.5071)  loss_mal_enc_0: 0.9878 (1.0114)  loss_bbox_enc_0: 0.4533 (0.4418)  loss_giou_enc_0: 0.6221 (0.6630)  loss_mal_dn_0: 0.7476 (0.7494)  loss_bbox_dn_0: 0.3809 (0.3851)  loss_giou_dn_0: 0.5830 (0.5997)  loss_fgl_dn_0: 1.2016 (1.2133)  loss_ddf_dn_0: 0.3677 (0.3953)  loss_mal_dn_1: 0.6938 (0.6884)  loss_bbox_dn_1: 0.2856 (0.3101)  loss_giou_dn_1: 0.4398 (0.4562)  loss_fgl_dn_1: 1.1265 (1.1369)  loss_ddf_dn_1: 0.0221 (0.0236)  loss_mal_dn_2: 0.6792 (0.6763)  loss_bbox_dn_2: 0.2644 (0.3027)  loss_giou_dn_2: 0.4277 (0.4427)  loss_fgl_dn_2: 1.1212 (1.1317)  loss_mal_dn_pre: 0.7461 (0.7493)  loss_bbox_dn_pre: 0.3848 (0.3862)  loss_giou_dn_pre: 0.5760 (0.5997)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.39it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.662\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.879\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.801\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.318\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.422\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.690\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.710\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.811\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.841\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.388\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.643\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.865\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.965\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:27:52.678\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:27:52.679\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 5 / mAP: 0.6622873424382322\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:27:52.680\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 5, 'coco_eval_bbox': 0.6622873424382322}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:27:52.681\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 6/30\u001b[0m\n",
+      "Epoch 6: 100%|██████████| 403/403 [02:35<00:00,  2.59it/s, loss=20.1836]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 21.1207 (22.3083)  loss_mal: 0.8169 (0.8761)  loss_bbox: 0.2576 (0.2981)  loss_giou: 0.3693 (0.4456)  loss_fgl: 1.1000 (1.1290)  loss_mal_aux_0: 0.9194 (0.9191)  loss_bbox_aux_0: 0.2915 (0.3241)  loss_giou_aux_0: 0.4782 (0.4903)  loss_fgl_aux_0: 1.1723 (1.1735)  loss_ddf_aux_0: 0.1252 (0.1190)  loss_mal_aux_1: 0.8462 (0.8890)  loss_bbox_aux_1: 0.2606 (0.2994)  loss_giou_aux_1: 0.3910 (0.4482)  loss_fgl_aux_1: 1.1018 (1.1309)  loss_ddf_aux_1: 0.0057 (0.0064)  loss_mal_pre: 0.9116 (0.9172)  loss_bbox_pre: 0.2880 (0.3224)  loss_giou_pre: 0.4713 (0.4886)  loss_mal_enc_0: 0.9834 (0.9902)  loss_bbox_enc_0: 0.3662 (0.4330)  loss_giou_enc_0: 0.5753 (0.6498)  loss_mal_dn_0: 0.7329 (0.7374)  loss_bbox_dn_0: 0.3317 (0.3661)  loss_giou_dn_0: 0.5297 (0.5690)  loss_fgl_dn_0: 1.2138 (1.2137)  loss_ddf_dn_0: 0.3487 (0.3694)  loss_mal_dn_1: 0.6479 (0.6664)  loss_bbox_dn_1: 0.2370 (0.2950)  loss_giou_dn_1: 0.3998 (0.4341)  loss_fgl_dn_1: 1.1124 (1.1255)  loss_ddf_dn_1: 0.0154 (0.0198)  loss_mal_dn_2: 0.6411 (0.6554)  loss_bbox_dn_2: 0.2343 (0.2887)  loss_giou_dn_2: 0.3889 (0.4230)  loss_fgl_dn_2: 1.1086 (1.1207)  loss_mal_dn_pre: 0.7334 (0.7375)  loss_bbox_dn_pre: 0.3286 (0.3669)  loss_giou_dn_pre: 0.5174 (0.5695)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.04it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.682\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.890\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.823\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.320\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.448\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.710\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.726\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.819\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.855\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.388\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.701\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.878\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.986\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.966\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:30:33.629\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:30:33.631\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 6 / mAP: 0.6822072165355043\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:30:33.632\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 6, 'coco_eval_bbox': 0.6822072165355043}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:30:33.633\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 7/30\u001b[0m\n",
+      "Epoch 7: 100%|██████████| 403/403 [02:39<00:00,  2.53it/s, loss=17.5472]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 18.9713 (21.7675)  loss_mal: 0.7173 (0.8452)  loss_bbox: 0.2412 (0.2925)  loss_giou: 0.3486 (0.4270)  loss_fgl: 1.0931 (1.1131)  loss_mal_aux_0: 0.7935 (0.8959)  loss_bbox_aux_0: 0.2577 (0.3166)  loss_giou_aux_0: 0.3866 (0.4702)  loss_fgl_aux_0: 1.1550 (1.1628)  loss_ddf_aux_0: 0.1087 (0.1145)  loss_mal_aux_1: 0.7397 (0.8596)  loss_bbox_aux_1: 0.2419 (0.2937)  loss_giou_aux_1: 0.3497 (0.4293)  loss_fgl_aux_1: 1.0940 (1.1150)  loss_ddf_aux_1: 0.0053 (0.0060)  loss_mal_pre: 0.7915 (0.8937)  loss_bbox_pre: 0.2541 (0.3153)  loss_giou_pre: 0.3913 (0.4686)  loss_mal_enc_0: 0.8999 (0.9655)  loss_bbox_enc_0: 0.3796 (0.4260)  loss_giou_enc_0: 0.5565 (0.6307)  loss_mal_dn_0: 0.7197 (0.7270)  loss_bbox_dn_0: 0.2577 (0.3543)  loss_giou_dn_0: 0.4614 (0.5459)  loss_fgl_dn_0: 1.2058 (1.2112)  loss_ddf_dn_0: 0.3435 (0.3523)  loss_mal_dn_1: 0.6206 (0.6491)  loss_bbox_dn_1: 0.1861 (0.2850)  loss_giou_dn_1: 0.3212 (0.4138)  loss_fgl_dn_1: 1.1003 (1.1132)  loss_ddf_dn_1: 0.0164 (0.0183)  loss_mal_dn_2: 0.6060 (0.6390)  loss_bbox_dn_2: 0.1836 (0.2789)  loss_giou_dn_2: 0.3113 (0.4031)  loss_fgl_dn_2: 1.0946 (1.1077)  loss_mal_dn_pre: 0.7202 (0.7268)  loss_bbox_dn_pre: 0.2615 (0.3548)  loss_giou_dn_pre: 0.4735 (0.5460)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.21it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.700\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.905\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.820\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.295\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.475\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.729\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.727\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.826\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.856\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.623\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.882\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.963\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:33:18.270\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:33:18.272\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 7 / mAP: 0.7000444718426131\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:33:18.273\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 7, 'coco_eval_bbox': 0.7000444718426131}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:33:18.274\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 8/30\u001b[0m\n",
+      "Epoch 8: 100%|██████████| 403/403 [02:35<00:00,  2.59it/s, loss=17.4584]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 21.4912 (21.4661)  loss_mal: 0.8330 (0.8350)  loss_bbox: 0.2257 (0.2775)  loss_giou: 0.4585 (0.4169)  loss_fgl: 1.0945 (1.1134)  loss_mal_aux_0: 0.8643 (0.8871)  loss_bbox_aux_0: 0.2455 (0.3005)  loss_giou_aux_0: 0.5021 (0.4594)  loss_fgl_aux_0: 1.1332 (1.1631)  loss_ddf_aux_0: 0.0936 (0.1138)  loss_mal_aux_1: 0.8232 (0.8490)  loss_bbox_aux_1: 0.2281 (0.2787)  loss_giou_aux_1: 0.4592 (0.4192)  loss_fgl_aux_1: 1.0932 (1.1150)  loss_ddf_aux_1: 0.0051 (0.0057)  loss_mal_pre: 0.8628 (0.8857)  loss_bbox_pre: 0.2388 (0.2992)  loss_giou_pre: 0.5006 (0.4578)  loss_mal_enc_0: 0.9238 (0.9542)  loss_bbox_enc_0: 0.3917 (0.4154)  loss_giou_enc_0: 0.6373 (0.6271)  loss_mal_dn_0: 0.7085 (0.7217)  loss_bbox_dn_0: 0.2566 (0.3459)  loss_giou_dn_0: 0.5644 (0.5339)  loss_fgl_dn_0: 1.2018 (1.2102)  loss_ddf_dn_0: 0.2908 (0.3378)  loss_mal_dn_1: 0.6226 (0.6401)  loss_bbox_dn_1: 0.1906 (0.2769)  loss_giou_dn_1: 0.4430 (0.4039)  loss_fgl_dn_1: 1.0955 (1.1071)  loss_ddf_dn_1: 0.0148 (0.0168)  loss_mal_dn_2: 0.6196 (0.6293)  loss_bbox_dn_2: 0.1879 (0.2712)  loss_giou_dn_2: 0.4266 (0.3939)  loss_fgl_dn_2: 1.0947 (1.1020)  loss_mal_dn_pre: 0.7114 (0.7215)  loss_bbox_dn_pre: 0.2604 (0.3463)  loss_giou_dn_pre: 0.5645 (0.5340)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.25it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.709\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.912\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.842\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.301\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.485\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.735\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.732\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.828\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.858\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.656\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.882\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.960\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:35:59.645\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:35:59.647\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 8 / mAP: 0.7092175177408475\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:35:59.648\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 8, 'coco_eval_bbox': 0.7092175177408475}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:35:59.648\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 9/30\u001b[0m\n",
+      "Epoch 9: 100%|██████████| 403/403 [02:39<00:00,  2.52it/s, loss=19.0965]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 22.2318 (21.1437)  loss_mal: 0.8521 (0.8226)  loss_bbox: 0.2883 (0.2711)  loss_giou: 0.3569 (0.4079)  loss_fgl: 1.1182 (1.1065)  loss_mal_aux_0: 0.9609 (0.8789)  loss_bbox_aux_0: 0.3109 (0.2946)  loss_giou_aux_0: 0.4114 (0.4484)  loss_fgl_aux_0: 1.1740 (1.1601)  loss_ddf_aux_0: 0.1017 (0.1160)  loss_mal_aux_1: 0.8691 (0.8375)  loss_bbox_aux_1: 0.2874 (0.2728)  loss_giou_aux_1: 0.3613 (0.4103)  loss_fgl_aux_1: 1.1219 (1.1086)  loss_ddf_aux_1: 0.0058 (0.0058)  loss_mal_pre: 0.9619 (0.8771)  loss_bbox_pre: 0.3116 (0.2931)  loss_giou_pre: 0.4106 (0.4467)  loss_mal_enc_0: 0.9399 (0.9453)  loss_bbox_enc_0: 0.3912 (0.4017)  loss_giou_enc_0: 0.5606 (0.6072)  loss_mal_dn_0: 0.7202 (0.7178)  loss_bbox_dn_0: 0.3179 (0.3323)  loss_giou_dn_0: 0.4664 (0.5144)  loss_fgl_dn_0: 1.2062 (1.2092)  loss_ddf_dn_0: 0.2886 (0.3212)  loss_mal_dn_1: 0.6475 (0.6326)  loss_bbox_dn_1: 0.2696 (0.2668)  loss_giou_dn_1: 0.3752 (0.3926)  loss_fgl_dn_1: 1.1150 (1.1011)  loss_ddf_dn_1: 0.0148 (0.0160)  loss_mal_dn_2: 0.6304 (0.6226)  loss_bbox_dn_2: 0.2668 (0.2613)  loss_giou_dn_2: 0.3660 (0.3834)  loss_fgl_dn_2: 1.1113 (1.0954)  loss_mal_dn_pre: 0.7178 (0.7175)  loss_bbox_dn_pre: 0.3226 (0.3328)  loss_giou_dn_pre: 0.4614 (0.5146)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.01it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.712\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.913\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.844\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.318\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.521\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.738\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.737\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.827\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.859\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.661\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.885\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.983\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.969\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:38:44.889\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:38:44.891\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 9 / mAP: 0.7116401325787367\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:38:44.893\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 9, 'coco_eval_bbox': 0.7116401325787367}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:38:44.893\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 10/30\u001b[0m\n",
+      "Epoch 10: 100%|██████████| 403/403 [02:38<00:00,  2.54it/s, loss=21.0231]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 19.4502 (20.7918)  loss_mal: 0.6973 (0.7950)  loss_bbox: 0.2107 (0.2701)  loss_giou: 0.3313 (0.4011)  loss_fgl: 1.0559 (1.0942)  loss_mal_aux_0: 0.7964 (0.8470)  loss_bbox_aux_0: 0.2393 (0.2924)  loss_giou_aux_0: 0.3689 (0.4407)  loss_fgl_aux_0: 1.1337 (1.1491)  loss_ddf_aux_0: 0.1392 (0.1178)  loss_mal_aux_1: 0.6943 (0.8076)  loss_bbox_aux_1: 0.2093 (0.2713)  loss_giou_aux_1: 0.3301 (0.4033)  loss_fgl_aux_1: 1.0662 (1.0964)  loss_ddf_aux_1: 0.0044 (0.0056)  loss_mal_pre: 0.7915 (0.8454)  loss_bbox_pre: 0.2385 (0.2911)  loss_giou_pre: 0.3701 (0.4392)  loss_mal_enc_0: 0.8989 (0.9271)  loss_bbox_enc_0: 0.3918 (0.4002)  loss_giou_enc_0: 0.5625 (0.6035)  loss_mal_dn_0: 0.6929 (0.7073)  loss_bbox_dn_0: 0.2518 (0.3291)  loss_giou_dn_0: 0.4542 (0.5031)  loss_fgl_dn_0: 1.2080 (1.2050)  loss_ddf_dn_0: 0.2991 (0.3086)  loss_mal_dn_1: 0.5728 (0.6173)  loss_bbox_dn_1: 0.1897 (0.2660)  loss_giou_dn_1: 0.3222 (0.3838)  loss_fgl_dn_1: 1.0695 (1.0906)  loss_ddf_dn_1: 0.0114 (0.0150)  loss_mal_dn_2: 0.5635 (0.6075)  loss_bbox_dn_2: 0.1815 (0.2608)  loss_giou_dn_2: 0.3150 (0.3751)  loss_fgl_dn_2: 1.0622 (1.0850)  loss_mal_dn_pre: 0.6958 (0.7071)  loss_bbox_dn_pre: 0.2525 (0.3294)  loss_giou_dn_pre: 0.4569 (0.5032)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.24it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.732\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.925\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.852\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.310\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.547\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.758\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.750\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.829\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.863\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.690\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.885\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.981\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.978\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:41:28.873\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:41:28.876\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 10 / mAP: 0.7315492857434059\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:41:28.877\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 10, 'coco_eval_bbox': 0.7315492857434059}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:41:28.878\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 11/30\u001b[0m\n",
+      "Epoch 11: 100%|██████████| 403/403 [02:38<00:00,  2.55it/s, loss=15.9105]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 21.2652 (20.6308)  loss_mal: 0.8345 (0.7888)  loss_bbox: 0.2613 (0.2627)  loss_giou: 0.3865 (0.3996)  loss_fgl: 1.1007 (1.0931)  loss_mal_aux_0: 0.8511 (0.8487)  loss_bbox_aux_0: 0.2760 (0.2839)  loss_giou_aux_0: 0.4230 (0.4376)  loss_fgl_aux_0: 1.1512 (1.1499)  loss_ddf_aux_0: 0.0975 (0.1116)  loss_mal_aux_1: 0.8145 (0.8039)  loss_bbox_aux_1: 0.2645 (0.2640)  loss_giou_aux_1: 0.3899 (0.4018)  loss_fgl_aux_1: 1.1006 (1.0951)  loss_ddf_aux_1: 0.0058 (0.0056)  loss_mal_pre: 0.8491 (0.8467)  loss_bbox_pre: 0.2719 (0.2827)  loss_giou_pre: 0.4218 (0.4361)  loss_mal_enc_0: 0.9038 (0.9195)  loss_bbox_enc_0: 0.3772 (0.3872)  loss_giou_enc_0: 0.5458 (0.5931)  loss_mal_dn_0: 0.7300 (0.7041)  loss_bbox_dn_0: 0.3059 (0.3208)  loss_giou_dn_0: 0.5219 (0.4981)  loss_fgl_dn_0: 1.2091 (1.2037)  loss_ddf_dn_0: 0.3002 (0.3049)  loss_mal_dn_1: 0.6597 (0.6133)  loss_bbox_dn_1: 0.2225 (0.2578)  loss_giou_dn_1: 0.4095 (0.3799)  loss_fgl_dn_1: 1.1170 (1.0881)  loss_ddf_dn_1: 0.0131 (0.0141)  loss_mal_dn_2: 0.6562 (0.6044)  loss_bbox_dn_2: 0.2111 (0.2527)  loss_giou_dn_2: 0.4056 (0.3717)  loss_fgl_dn_2: 1.1157 (1.0826)  loss_mal_dn_pre: 0.7285 (0.7036)  loss_bbox_dn_pre: 0.3045 (0.3213)  loss_giou_dn_pre: 0.5190 (0.4979)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.95it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.734\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.932\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.865\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.297\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.551\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.758\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.743\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.833\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.857\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.722\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.878\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.986\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.965\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:44:12.459\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:44:12.460\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 11 / mAP: 0.733951660171522\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:44:12.462\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 11, 'coco_eval_bbox': 0.733951660171522}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:44:12.462\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 12/30\u001b[0m\n",
+      "Epoch 12: 100%|██████████| 403/403 [02:51<00:00,  2.36it/s, loss=18.4198]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 19.6123 (20.2896)  loss_mal: 0.7573 (0.7795)  loss_bbox: 0.2241 (0.2513)  loss_giou: 0.3338 (0.3885)  loss_fgl: 1.0901 (1.0876)  loss_mal_aux_0: 0.7593 (0.8389)  loss_bbox_aux_0: 0.2374 (0.2727)  loss_giou_aux_0: 0.3840 (0.4268)  loss_fgl_aux_0: 1.1262 (1.1443)  loss_ddf_aux_0: 0.1034 (0.1141)  loss_mal_aux_1: 0.7583 (0.7926)  loss_bbox_aux_1: 0.2220 (0.2526)  loss_giou_aux_1: 0.3348 (0.3910)  loss_fgl_aux_1: 1.0894 (1.0899)  loss_ddf_aux_1: 0.0058 (0.0058)  loss_mal_pre: 0.7617 (0.8361)  loss_bbox_pre: 0.2372 (0.2717)  loss_giou_pre: 0.3882 (0.4253)  loss_mal_enc_0: 0.8267 (0.9025)  loss_bbox_enc_0: 0.3286 (0.3615)  loss_giou_enc_0: 0.5334 (0.5699)  loss_mal_dn_0: 0.6909 (0.6992)  loss_bbox_dn_0: 0.2776 (0.3116)  loss_giou_dn_0: 0.4134 (0.4805)  loss_fgl_dn_0: 1.2029 (1.2003)  loss_ddf_dn_0: 0.2957 (0.2984)  loss_mal_dn_1: 0.5859 (0.6065)  loss_bbox_dn_1: 0.2175 (0.2505)  loss_giou_dn_1: 0.2913 (0.3685)  loss_fgl_dn_1: 1.0978 (1.0836)  loss_ddf_dn_1: 0.0161 (0.0141)  loss_mal_dn_2: 0.5771 (0.5981)  loss_bbox_dn_2: 0.2214 (0.2454)  loss_giou_dn_2: 0.2843 (0.3610)  loss_fgl_dn_2: 1.0936 (1.0782)  loss_mal_dn_pre: 0.6924 (0.6988)  loss_bbox_dn_pre: 0.2736 (0.3119)  loss_giou_dn_pre: 0.4296 (0.4800)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.50it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.735\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.932\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.857\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.314\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.521\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.761\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.742\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.824\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.858\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.710\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.880\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.986\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.966\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:47:09.397\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:47:09.399\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 12 / mAP: 0.7349376682281119\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:47:09.400\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 12, 'coco_eval_bbox': 0.7349376682281119}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:47:09.401\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 13/30\u001b[0m\n",
+      "Epoch 13: 100%|██████████| 403/403 [02:47<00:00,  2.40it/s, loss=21.7465]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 18.6997 (20.1207)  loss_mal: 0.6167 (0.7653)  loss_bbox: 0.2162 (0.2517)  loss_giou: 0.3351 (0.3858)  loss_fgl: 1.0748 (1.0815)  loss_mal_aux_0: 0.7031 (0.8277)  loss_bbox_aux_0: 0.2331 (0.2731)  loss_giou_aux_0: 0.3520 (0.4236)  loss_fgl_aux_0: 1.1311 (1.1375)  loss_ddf_aux_0: 0.1033 (0.1141)  loss_mal_aux_1: 0.6274 (0.7815)  loss_bbox_aux_1: 0.2148 (0.2532)  loss_giou_aux_1: 0.3365 (0.3880)  loss_fgl_aux_1: 1.0727 (1.0834)  loss_ddf_aux_1: 0.0061 (0.0057)  loss_mal_pre: 0.7002 (0.8258)  loss_bbox_pre: 0.2410 (0.2720)  loss_giou_pre: 0.3513 (0.4216)  loss_mal_enc_0: 0.8428 (0.8913)  loss_bbox_enc_0: 0.3350 (0.3585)  loss_giou_enc_0: 0.4644 (0.5599)  loss_mal_dn_0: 0.6592 (0.6940)  loss_bbox_dn_0: 0.2506 (0.3090)  loss_giou_dn_0: 0.4224 (0.4761)  loss_fgl_dn_0: 1.1822 (1.1975)  loss_ddf_dn_0: 0.2562 (0.2908)  loss_mal_dn_1: 0.5698 (0.6007)  loss_bbox_dn_1: 0.2032 (0.2488)  loss_giou_dn_1: 0.3269 (0.3660)  loss_fgl_dn_1: 1.0826 (1.0780)  loss_ddf_dn_1: 0.0134 (0.0135)  loss_mal_dn_2: 0.5640 (0.5925)  loss_bbox_dn_2: 0.2016 (0.2436)  loss_giou_dn_2: 0.3235 (0.3585)  loss_fgl_dn_2: 1.0775 (1.0722)  loss_mal_dn_pre: 0.6582 (0.6933)  loss_bbox_dn_pre: 0.2522 (0.3094)  loss_giou_dn_pre: 0.4208 (0.4755)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.64it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.745\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.935\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.868\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.326\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.532\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.773\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.752\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.832\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.861\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.668\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.885\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.985\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.965\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:50:03.180\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:50:03.181\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 13 / mAP: 0.7448846448334132\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:50:03.182\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 13, 'coco_eval_bbox': 0.7448846448334132}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:50:03.182\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 14/30\u001b[0m\n",
+      "Epoch 14: 100%|██████████| 403/403 [02:50<00:00,  2.37it/s, loss=20.9278]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000200  loss: 20.9278 (19.7618)  loss_mal: 0.8281 (0.7522)  loss_bbox: 0.2677 (0.2474)  loss_giou: 0.4026 (0.3786)  loss_fgl: 1.0934 (1.0774)  loss_mal_aux_0: 0.8438 (0.8119)  loss_bbox_aux_0: 0.2797 (0.2663)  loss_giou_aux_0: 0.4250 (0.4129)  loss_fgl_aux_0: 1.1428 (1.1323)  loss_ddf_aux_0: 0.0984 (0.1112)  loss_mal_aux_1: 0.8145 (0.7654)  loss_bbox_aux_1: 0.2691 (0.2486)  loss_giou_aux_1: 0.3977 (0.3805)  loss_fgl_aux_1: 1.1056 (1.0789)  loss_ddf_aux_1: 0.0046 (0.0051)  loss_mal_pre: 0.8418 (0.8107)  loss_bbox_pre: 0.2823 (0.2656)  loss_giou_pre: 0.4256 (0.4110)  loss_mal_enc_0: 0.8823 (0.8717)  loss_bbox_enc_0: 0.3393 (0.3500)  loss_giou_enc_0: 0.5472 (0.5452)  loss_mal_dn_0: 0.7021 (0.6846)  loss_bbox_dn_0: 0.2906 (0.2945)  loss_giou_dn_0: 0.4850 (0.4580)  loss_fgl_dn_0: 1.1831 (1.1936)  loss_ddf_dn_0: 0.2345 (0.2738)  loss_mal_dn_1: 0.6162 (0.5901)  loss_bbox_dn_1: 0.2498 (0.2372)  loss_giou_dn_1: 0.3987 (0.3545)  loss_fgl_dn_1: 1.0777 (1.0744)  loss_ddf_dn_1: 0.0121 (0.0126)  loss_mal_dn_2: 0.6094 (0.5806)  loss_bbox_dn_2: 0.2387 (0.2328)  loss_giou_dn_2: 0.3905 (0.3474)  loss_fgl_dn_2: 1.0727 (1.0686)  loss_mal_dn_pre: 0.7017 (0.6839)  loss_bbox_dn_pre: 0.2902 (0.2952)  loss_giou_dn_pre: 0.4821 (0.4572)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.72it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.746\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.940\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.867\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.326\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.565\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.772\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.748\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.838\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.869\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.350\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.738\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.891\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.960\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:52:58.525\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:52:58.526\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 14 / mAP: 0.7455220349048505\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:52:58.527\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 14, 'coco_eval_bbox': 0.7455220349048505}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:52:58.528\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 15/30\u001b[0m\n",
+      "Epoch 15:   0%|          | 0/403 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     ### Attention --- Mixup is closed after epoch@ 15 ###\n",
+      "     ### Attention --- Mixup is closed after epoch@ 15 ###\n",
+      "     ### Attention --- Mixup is closed after epoch@ 15 ###\n",
+      "     ### Attention --- Mixup is closed after epoch@ 15 ###\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 15: 100%|██████████| 403/403 [02:07<00:00,  3.16it/s, loss=20.1273]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000198  loss: 19.9317 (20.3104)  loss_mal: 0.7983 (0.7992)  loss_bbox: 0.2762 (0.2823)  loss_giou: 0.2681 (0.2667)  loss_fgl: 1.0238 (1.0495)  loss_mal_aux_0: 0.8857 (0.9373)  loss_bbox_aux_0: 0.3308 (0.3453)  loss_giou_aux_0: 0.3168 (0.3268)  loss_fgl_aux_0: 1.1404 (1.1582)  loss_ddf_aux_0: 0.1118 (0.1239)  loss_mal_aux_1: 0.7471 (0.8367)  loss_bbox_aux_1: 0.2975 (0.2875)  loss_giou_aux_1: 0.2672 (0.2713)  loss_fgl_aux_1: 1.0334 (1.0563)  loss_ddf_aux_1: 0.0055 (0.0085)  loss_mal_pre: 0.8999 (0.9353)  loss_bbox_pre: 0.3299 (0.3436)  loss_giou_pre: 0.3108 (0.3249)  loss_mal_enc_0: 0.9492 (1.0459)  loss_bbox_enc_0: 0.5796 (0.5520)  loss_giou_enc_0: 0.4344 (0.4981)  loss_mal_dn_0: 0.6870 (0.6839)  loss_bbox_dn_0: 0.4121 (0.4139)  loss_giou_dn_0: 0.3955 (0.4135)  loss_fgl_dn_0: 1.2005 (1.2167)  loss_ddf_dn_0: 0.2141 (0.2389)  loss_mal_dn_1: 0.5527 (0.5608)  loss_bbox_dn_1: 0.2987 (0.2922)  loss_giou_dn_1: 0.2794 (0.2857)  loss_fgl_dn_1: 1.0781 (1.0659)  loss_ddf_dn_1: 0.0124 (0.0159)  loss_mal_dn_2: 0.5415 (0.5492)  loss_bbox_dn_2: 0.2851 (0.2792)  loss_giou_dn_2: 0.2727 (0.2744)  loss_fgl_dn_2: 1.0605 (1.0537)  loss_mal_dn_pre: 0.6855 (0.6831)  loss_bbox_dn_pre: 0.4280 (0.4203)  loss_giou_dn_pre: 0.3952 (0.4137)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.01it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.749\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.935\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.864\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.332\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.541\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.775\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.749\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.845\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.881\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.375\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.744\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.902\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.986\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.971\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:55:11.835\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:55:11.838\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 15 / mAP: 0.7491120947066922\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:55:11.840\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 15, 'coco_eval_bbox': 0.7491120947066922}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:55:11.841\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 16/30\u001b[0m\n",
+      "Epoch 16: 100%|██████████| 403/403 [02:10<00:00,  3.09it/s, loss=16.3773]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000193  loss: 19.8128 (19.4360)  loss_mal: 0.7065 (0.7303)  loss_bbox: 0.2798 (0.2574)  loss_giou: 0.2352 (0.2594)  loss_fgl: 1.0208 (1.0408)  loss_mal_aux_0: 0.8960 (0.8728)  loss_bbox_aux_0: 0.3127 (0.3194)  loss_giou_aux_0: 0.2940 (0.3175)  loss_fgl_aux_0: 1.1338 (1.1497)  loss_ddf_aux_0: 0.1221 (0.1252)  loss_mal_aux_1: 0.7095 (0.7680)  loss_bbox_aux_1: 0.2862 (0.2625)  loss_giou_aux_1: 0.2420 (0.2637)  loss_fgl_aux_1: 1.0331 (1.0469)  loss_ddf_aux_1: 0.0089 (0.0085)  loss_mal_pre: 0.8911 (0.8724)  loss_bbox_pre: 0.3185 (0.3171)  loss_giou_pre: 0.2907 (0.3152)  loss_mal_enc_0: 0.9165 (0.9855)  loss_bbox_enc_0: 0.5451 (0.5074)  loss_giou_enc_0: 0.4569 (0.4810)  loss_mal_dn_0: 0.6567 (0.6718)  loss_bbox_dn_0: 0.3762 (0.3690)  loss_giou_dn_0: 0.3814 (0.3939)  loss_fgl_dn_0: 1.2101 (1.2128)  loss_ddf_dn_0: 0.2644 (0.2385)  loss_mal_dn_1: 0.5234 (0.5399)  loss_bbox_dn_1: 0.2511 (0.2566)  loss_giou_dn_1: 0.2470 (0.2693)  loss_fgl_dn_1: 1.0380 (1.0522)  loss_ddf_dn_1: 0.0177 (0.0168)  loss_mal_dn_2: 0.5117 (0.5319)  loss_bbox_dn_2: 0.2462 (0.2441)  loss_giou_dn_2: 0.2414 (0.2578)  loss_fgl_dn_2: 1.0126 (1.0386)  loss_mal_dn_pre: 0.6562 (0.6710)  loss_bbox_dn_pre: 0.3743 (0.3766)  loss_giou_dn_pre: 0.3813 (0.3945)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:06<00:00,  5.61it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.12s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.752\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.940\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.871\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.326\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.539\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.780\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.750\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.852\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.880\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.362\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.747\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.901\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.971\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:57:29.077\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:57:29.079\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 16 / mAP: 0.7521780303897926\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:57:29.080\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 16, 'coco_eval_bbox': 0.7521780303897926}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:57:29.080\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 17/30\u001b[0m\n",
+      "Epoch 17: 100%|██████████| 403/403 [02:22<00:00,  2.84it/s, loss=15.9026]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000185  loss: 17.6556 (18.9795)  loss_mal: 0.5840 (0.6996)  loss_bbox: 0.2344 (0.2484)  loss_giou: 0.2175 (0.2501)  loss_fgl: 1.0095 (1.0246)  loss_mal_aux_0: 0.7803 (0.8315)  loss_bbox_aux_0: 0.2782 (0.3055)  loss_giou_aux_0: 0.2705 (0.3075)  loss_fgl_aux_0: 1.0928 (1.1354)  loss_ddf_aux_0: 0.1116 (0.1307)  loss_mal_aux_1: 0.6123 (0.7330)  loss_bbox_aux_1: 0.2313 (0.2539)  loss_giou_aux_1: 0.2244 (0.2553)  loss_fgl_aux_1: 1.0161 (1.0324)  loss_ddf_aux_1: 0.0067 (0.0096)  loss_mal_pre: 0.7812 (0.8297)  loss_bbox_pre: 0.2731 (0.3034)  loss_giou_pre: 0.2677 (0.3056)  loss_mal_enc_0: 0.8916 (0.9489)  loss_bbox_enc_0: 0.4443 (0.4845)  loss_giou_enc_0: 0.3902 (0.4633)  loss_mal_dn_0: 0.6289 (0.6617)  loss_bbox_dn_0: 0.3199 (0.3653)  loss_giou_dn_0: 0.3566 (0.3852)  loss_fgl_dn_0: 1.1953 (1.2052)  loss_ddf_dn_0: 0.2687 (0.2543)  loss_mal_dn_1: 0.4958 (0.5273)  loss_bbox_dn_1: 0.2162 (0.2537)  loss_giou_dn_1: 0.2471 (0.2612)  loss_fgl_dn_1: 0.9962 (1.0401)  loss_ddf_dn_1: 0.0159 (0.0185)  loss_mal_dn_2: 0.4785 (0.5148)  loss_bbox_dn_2: 0.2092 (0.2425)  loss_giou_dn_2: 0.2337 (0.2506)  loss_fgl_dn_2: 0.9722 (1.0267)  loss_mal_dn_pre: 0.6274 (0.6607)  loss_bbox_dn_pre: 0.3229 (0.3729)  loss_giou_dn_pre: 0.3595 (0.3859)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.55it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.755\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.940\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.870\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.327\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.553\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.781\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.755\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.851\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.884\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.388\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.741\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.907\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.973\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 17:59:57.066\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:59:57.067\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 17 / mAP: 0.7547366786897597\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:59:57.068\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 17, 'coco_eval_bbox': 0.7547366786897597}\u001b[0m\n",
+      "\u001b[32m2025-04-03 17:59:57.069\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 18/30\u001b[0m\n",
+      "Epoch 18: 100%|██████████| 403/403 [02:26<00:00,  2.74it/s, loss=15.5962]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000175  loss: 17.2417 (18.3438)  loss_mal: 0.6147 (0.6489)  loss_bbox: 0.2026 (0.2392)  loss_giou: 0.2272 (0.2401)  loss_fgl: 0.9790 (1.0120)  loss_mal_aux_0: 0.7031 (0.7865)  loss_bbox_aux_0: 0.2850 (0.2921)  loss_giou_aux_0: 0.2734 (0.2936)  loss_fgl_aux_0: 1.1185 (1.1235)  loss_ddf_aux_0: 0.1095 (0.1248)  loss_mal_aux_1: 0.6274 (0.6818)  loss_bbox_aux_1: 0.2071 (0.2435)  loss_giou_aux_1: 0.2306 (0.2442)  loss_fgl_aux_1: 0.9990 (1.0182)  loss_ddf_aux_1: 0.0069 (0.0085)  loss_mal_pre: 0.6992 (0.7861)  loss_bbox_pre: 0.2610 (0.2905)  loss_giou_pre: 0.2725 (0.2920)  loss_mal_enc_0: 0.8179 (0.9124)  loss_bbox_enc_0: 0.4712 (0.4667)  loss_giou_enc_0: 0.3959 (0.4437)  loss_mal_dn_0: 0.6240 (0.6486)  loss_bbox_dn_0: 0.3225 (0.3402)  loss_giou_dn_0: 0.3491 (0.3675)  loss_fgl_dn_0: 1.1921 (1.1984)  loss_ddf_dn_0: 0.2229 (0.2574)  loss_mal_dn_1: 0.4932 (0.5120)  loss_bbox_dn_1: 0.2218 (0.2331)  loss_giou_dn_1: 0.2402 (0.2488)  loss_fgl_dn_1: 1.0210 (1.0282)  loss_ddf_dn_1: 0.0139 (0.0168)  loss_mal_dn_2: 0.4719 (0.5014)  loss_bbox_dn_2: 0.1982 (0.2227)  loss_giou_dn_2: 0.2314 (0.2392)  loss_fgl_dn_2: 1.0097 (1.0161)  loss_mal_dn_pre: 0.6260 (0.6474)  loss_bbox_dn_pre: 0.3335 (0.3491)  loss_giou_dn_pre: 0.3528 (0.3683)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:06<00:00,  5.89it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.08s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.763\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.945\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.881\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.327\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.560\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.789\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.756\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.852\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.891\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.388\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.754\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.912\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.973\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 18:02:30.566\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:02:30.569\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 18 / mAP: 0.7627957927421951\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:02:30.570\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 18, 'coco_eval_bbox': 0.7627957927421951}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:02:30.571\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 19/30\u001b[0m\n",
+      "Epoch 19: 100%|██████████| 403/403 [02:40<00:00,  2.51it/s, loss=16.4251]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000163  loss: 16.6034 (18.2346)  loss_mal: 0.5200 (0.6342)  loss_bbox: 0.2188 (0.2431)  loss_giou: 0.2091 (0.2350)  loss_fgl: 0.9690 (1.0010)  loss_mal_aux_0: 0.6626 (0.7992)  loss_bbox_aux_0: 0.2632 (0.3039)  loss_giou_aux_0: 0.2757 (0.2907)  loss_fgl_aux_0: 1.1015 (1.1187)  loss_ddf_aux_0: 0.1149 (0.1322)  loss_mal_aux_1: 0.5605 (0.6767)  loss_bbox_aux_1: 0.2248 (0.2489)  loss_giou_aux_1: 0.2122 (0.2397)  loss_fgl_aux_1: 0.9805 (1.0080)  loss_ddf_aux_1: 0.0061 (0.0090)  loss_mal_pre: 0.6621 (0.7971)  loss_bbox_pre: 0.2674 (0.3029)  loss_giou_pre: 0.2651 (0.2888)  loss_mal_enc_0: 0.7920 (0.9136)  loss_bbox_enc_0: 0.3765 (0.4738)  loss_giou_enc_0: 0.4086 (0.4350)  loss_mal_dn_0: 0.6152 (0.6383)  loss_bbox_dn_0: 0.3035 (0.3409)  loss_giou_dn_0: 0.3368 (0.3530)  loss_fgl_dn_0: 1.1831 (1.1892)  loss_ddf_dn_0: 0.2515 (0.2671)  loss_mal_dn_1: 0.4597 (0.4993)  loss_bbox_dn_1: 0.1992 (0.2367)  loss_giou_dn_1: 0.2209 (0.2408)  loss_fgl_dn_1: 0.9906 (1.0133)  loss_ddf_dn_1: 0.0143 (0.0182)  loss_mal_dn_2: 0.4543 (0.4873)  loss_bbox_dn_2: 0.1826 (0.2262)  loss_giou_dn_2: 0.2160 (0.2314)  loss_fgl_dn_2: 0.9797 (0.9997)  loss_mal_dn_pre: 0.6113 (0.6374)  loss_bbox_dn_pre: 0.3145 (0.3497)  loss_giou_dn_pre: 0.3387 (0.3542)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:06<00:00,  5.70it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.765\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.943\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.884\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.327\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.557\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.792\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.759\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.857\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.892\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.400\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.743\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.914\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.976\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 18:05:17.992\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:05:17.995\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 19 / mAP: 0.7645490055918427\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:05:17.997\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 19, 'coco_eval_bbox': 0.7645490055918427}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:05:17.997\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 20/30\u001b[0m\n",
+      "Epoch 20: 100%|██████████| 403/403 [02:31<00:00,  2.66it/s, loss=14.1788]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000150  loss: 16.8611 (17.7661)  loss_mal: 0.5112 (0.6124)  loss_bbox: 0.2122 (0.2304)  loss_giou: 0.2174 (0.2304)  loss_fgl: 0.9458 (0.9972)  loss_mal_aux_0: 0.6450 (0.7616)  loss_bbox_aux_0: 0.2463 (0.2830)  loss_giou_aux_0: 0.2547 (0.2811)  loss_fgl_aux_0: 1.0690 (1.1091)  loss_ddf_aux_0: 0.0886 (0.1294)  loss_mal_aux_1: 0.5283 (0.6529)  loss_bbox_aux_1: 0.2221 (0.2349)  loss_giou_aux_1: 0.2181 (0.2345)  loss_fgl_aux_1: 0.9585 (1.0045)  loss_ddf_aux_1: 0.0058 (0.0086)  loss_mal_pre: 0.6436 (0.7609)  loss_bbox_pre: 0.2489 (0.2814)  loss_giou_pre: 0.2541 (0.2793)  loss_mal_enc_0: 0.7749 (0.8737)  loss_bbox_enc_0: 0.3861 (0.4466)  loss_giou_enc_0: 0.3774 (0.4283)  loss_mal_dn_0: 0.5981 (0.6303)  loss_bbox_dn_0: 0.2843 (0.3193)  loss_giou_dn_0: 0.2986 (0.3455)  loss_fgl_dn_0: 1.1442 (1.1827)  loss_ddf_dn_0: 0.2013 (0.2564)  loss_mal_dn_1: 0.4629 (0.4923)  loss_bbox_dn_1: 0.1963 (0.2208)  loss_giou_dn_1: 0.2167 (0.2356)  loss_fgl_dn_1: 0.9590 (1.0071)  loss_ddf_dn_1: 0.0099 (0.0168)  loss_mal_dn_2: 0.4417 (0.4808)  loss_bbox_dn_2: 0.1906 (0.2118)  loss_giou_dn_2: 0.2068 (0.2271)  loss_fgl_dn_2: 0.9373 (0.9943)  loss_mal_dn_pre: 0.5977 (0.6295)  loss_bbox_dn_pre: 0.2987 (0.3287)  loss_giou_dn_pre: 0.3021 (0.3469)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.96it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.766\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.945\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.884\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.327\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.559\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.792\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.760\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.855\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.895\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.412\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.766\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.914\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.968\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 18:07:55.162\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:07:55.163\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 20 / mAP: 0.7657997070395409\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:07:55.164\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 20, 'coco_eval_bbox': 0.7657997070395409}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:07:55.164\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 21/30\u001b[0m\n",
+      "Epoch 21: 100%|██████████| 403/403 [02:21<00:00,  2.86it/s, loss=15.4293]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000137  loss: 15.7880 (16.9348)  loss_mal: 0.5342 (0.5650)  loss_bbox: 0.1775 (0.2089)  loss_giou: 0.2102 (0.2224)  loss_fgl: 0.9554 (0.9755)  loss_mal_aux_0: 0.6797 (0.7063)  loss_bbox_aux_0: 0.2187 (0.2537)  loss_giou_aux_0: 0.2373 (0.2675)  loss_fgl_aux_0: 1.0551 (1.0833)  loss_ddf_aux_0: 0.1013 (0.1122)  loss_mal_aux_1: 0.5859 (0.5979)  loss_bbox_aux_1: 0.1673 (0.2118)  loss_giou_aux_1: 0.2118 (0.2255)  loss_fgl_aux_1: 0.9681 (0.9816)  loss_ddf_aux_1: 0.0069 (0.0069)  loss_mal_pre: 0.6763 (0.7042)  loss_bbox_pre: 0.2150 (0.2524)  loss_giou_pre: 0.2368 (0.2658)  loss_mal_enc_0: 0.7646 (0.8429)  loss_bbox_enc_0: 0.4078 (0.4085)  loss_giou_enc_0: 0.3765 (0.4111)  loss_mal_dn_0: 0.5952 (0.6119)  loss_bbox_dn_0: 0.2555 (0.2932)  loss_giou_dn_0: 0.3052 (0.3268)  loss_fgl_dn_0: 1.1483 (1.1682)  loss_ddf_dn_0: 0.2485 (0.2443)  loss_mal_dn_1: 0.4426 (0.4696)  loss_bbox_dn_1: 0.1622 (0.2016)  loss_giou_dn_1: 0.2095 (0.2235)  loss_fgl_dn_1: 0.9688 (0.9884)  loss_ddf_dn_1: 0.0145 (0.0139)  loss_mal_dn_2: 0.4280 (0.4603)  loss_bbox_dn_2: 0.1498 (0.1937)  loss_giou_dn_2: 0.1964 (0.2162)  loss_fgl_dn_2: 0.9483 (0.9768)  loss_mal_dn_pre: 0.5928 (0.6113)  loss_bbox_dn_pre: 0.2546 (0.3033)  loss_giou_dn_pre: 0.3028 (0.3287)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.24it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.768\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.945\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.887\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.327\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.563\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.795\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.762\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.856\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.896\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.400\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.765\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.916\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.970\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 18:10:22.551\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:10:22.553\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 21 / mAP: 0.768254119915405\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:10:22.554\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 21, 'coco_eval_bbox': 0.768254119915405}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:10:22.554\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 22/30\u001b[0m\n",
+      "Epoch 22: 100%|██████████| 403/403 [02:21<00:00,  2.86it/s, loss=14.4668]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000125  loss: 16.3904 (16.6350)  loss_mal: 0.5361 (0.5475)  loss_bbox: 0.1921 (0.2080)  loss_giou: 0.1990 (0.2127)  loss_fgl: 0.9593 (0.9674)  loss_mal_aux_0: 0.6875 (0.7062)  loss_bbox_aux_0: 0.2302 (0.2478)  loss_giou_aux_0: 0.2496 (0.2528)  loss_fgl_aux_0: 1.0698 (1.0712)  loss_ddf_aux_0: 0.1208 (0.1088)  loss_mal_aux_1: 0.5830 (0.5845)  loss_bbox_aux_1: 0.1969 (0.2116)  loss_giou_aux_1: 0.1968 (0.2161)  loss_fgl_aux_1: 0.9726 (0.9744)  loss_ddf_aux_1: 0.0059 (0.0071)  loss_mal_pre: 0.6880 (0.7043)  loss_bbox_pre: 0.2326 (0.2462)  loss_giou_pre: 0.2550 (0.2509)  loss_mal_enc_0: 0.8042 (0.8336)  loss_bbox_enc_0: 0.4508 (0.4006)  loss_giou_enc_0: 0.3759 (0.3911)  loss_mal_dn_0: 0.5933 (0.6027)  loss_bbox_dn_0: 0.2804 (0.2815)  loss_giou_dn_0: 0.3076 (0.3138)  loss_fgl_dn_0: 1.1525 (1.1626)  loss_ddf_dn_0: 0.2633 (0.2392)  loss_mal_dn_1: 0.4421 (0.4606)  loss_bbox_dn_1: 0.1780 (0.1954)  loss_giou_dn_1: 0.2019 (0.2161)  loss_fgl_dn_1: 0.9601 (0.9808)  loss_ddf_dn_1: 0.0126 (0.0144)  loss_mal_dn_2: 0.4304 (0.4508)  loss_bbox_dn_2: 0.1691 (0.1879)  loss_giou_dn_2: 0.1906 (0.2089)  loss_fgl_dn_2: 0.9294 (0.9688)  loss_mal_dn_pre: 0.5942 (0.6018)  loss_bbox_dn_pre: 0.2908 (0.2912)  loss_giou_dn_pre: 0.3022 (0.3157)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:06<00:00,  5.99it/s]\n",
+      "\u001b[32m2025-04-03 18:12:49.805\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 21, 'coco_eval_bbox': 0.768254119915405}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:12:49.805\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 23/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.10s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.768\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.944\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.886\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.327\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.561\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.795\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.761\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.856\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.894\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.400\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.755\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.915\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.973\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 23: 100%|██████████| 403/403 [02:22<00:00,  2.83it/s, loss=14.6553]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000115  loss: 15.6915 (16.4530)  loss_mal: 0.4790 (0.5597)  loss_bbox: 0.1874 (0.2023)  loss_giou: 0.1895 (0.2071)  loss_fgl: 0.9422 (0.9543)  loss_mal_aux_0: 0.6631 (0.7068)  loss_bbox_aux_0: 0.2210 (0.2443)  loss_giou_aux_0: 0.2229 (0.2477)  loss_fgl_aux_0: 1.0197 (1.0580)  loss_ddf_aux_0: 0.1151 (0.1152)  loss_mal_aux_1: 0.5093 (0.5990)  loss_bbox_aux_1: 0.1815 (0.2055)  loss_giou_aux_1: 0.1956 (0.2102)  loss_fgl_aux_1: 0.9541 (0.9601)  loss_ddf_aux_1: 0.0082 (0.0068)  loss_mal_pre: 0.6597 (0.7052)  loss_bbox_pre: 0.2244 (0.2436)  loss_giou_pre: 0.2226 (0.2465)  loss_mal_enc_0: 0.7739 (0.7968)  loss_bbox_enc_0: 0.3460 (0.3962)  loss_giou_enc_0: 0.3305 (0.3837)  loss_mal_dn_0: 0.5815 (0.5975)  loss_bbox_dn_0: 0.2540 (0.2774)  loss_giou_dn_0: 0.2820 (0.3088)  loss_fgl_dn_0: 1.1379 (1.1505)  loss_ddf_dn_0: 0.2526 (0.2567)  loss_mal_dn_1: 0.4453 (0.4538)  loss_bbox_dn_1: 0.1895 (0.1905)  loss_giou_dn_1: 0.1989 (0.2106)  loss_fgl_dn_1: 0.9457 (0.9636)  loss_ddf_dn_1: 0.0153 (0.0143)  loss_mal_dn_2: 0.4351 (0.4447)  loss_bbox_dn_2: 0.1789 (0.1831)  loss_giou_dn_2: 0.1957 (0.2039)  loss_fgl_dn_2: 0.9375 (0.9518)  loss_mal_dn_pre: 0.5815 (0.5969)  loss_bbox_dn_pre: 0.2628 (0.2888)  loss_giou_dn_pre: 0.2887 (0.3112)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.82it/s]\n",
+      "\u001b[32m2025-04-03 18:15:17.578\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 21, 'coco_eval_bbox': 0.768254119915405}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:15:17.578\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 24/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.768\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.946\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.890\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.327\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.563\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.794\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.762\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.856\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.894\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.400\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.759\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.914\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.973\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 24: 100%|██████████| 403/403 [02:20<00:00,  2.87it/s, loss=14.2059]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000107  loss: 15.0645 (15.9933)  loss_mal: 0.4485 (0.5282)  loss_bbox: 0.1510 (0.1950)  loss_giou: 0.1765 (0.2066)  loss_fgl: 0.9247 (0.9480)  loss_mal_aux_0: 0.5601 (0.6473)  loss_bbox_aux_0: 0.2311 (0.2329)  loss_giou_aux_0: 0.2109 (0.2445)  loss_fgl_aux_0: 1.0146 (1.0467)  loss_ddf_aux_0: 0.0932 (0.1071)  loss_mal_aux_1: 0.4680 (0.5497)  loss_bbox_aux_1: 0.1499 (0.1981)  loss_giou_aux_1: 0.1756 (0.2096)  loss_fgl_aux_1: 0.9271 (0.9537)  loss_ddf_aux_1: 0.0054 (0.0065)  loss_mal_pre: 0.5581 (0.6449)  loss_bbox_pre: 0.2319 (0.2322)  loss_giou_pre: 0.2066 (0.2434)  loss_mal_enc_0: 0.6748 (0.7656)  loss_bbox_enc_0: 0.3103 (0.3751)  loss_giou_enc_0: 0.3225 (0.3777)  loss_mal_dn_0: 0.5669 (0.5876)  loss_bbox_dn_0: 0.2471 (0.2665)  loss_giou_dn_0: 0.2767 (0.3014)  loss_fgl_dn_0: 1.1160 (1.1435)  loss_ddf_dn_0: 0.2286 (0.2422)  loss_mal_dn_1: 0.4026 (0.4444)  loss_bbox_dn_1: 0.1698 (0.1847)  loss_giou_dn_1: 0.1916 (0.2073)  loss_fgl_dn_1: 0.9361 (0.9593)  loss_ddf_dn_1: 0.0124 (0.0132)  loss_mal_dn_2: 0.3982 (0.4349)  loss_bbox_dn_2: 0.1590 (0.1781)  loss_giou_dn_2: 0.1866 (0.2013)  loss_fgl_dn_2: 0.9287 (0.9488)  loss_mal_dn_pre: 0.5630 (0.5871)  loss_bbox_dn_pre: 0.2702 (0.2768)  loss_giou_dn_pre: 0.2767 (0.3038)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.95it/s]\n",
+      "\u001b[32m2025-04-03 18:17:43.453\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 21, 'coco_eval_bbox': 0.768254119915405}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:17:43.453\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 25/30\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.768\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.946\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.891\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.327\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.563\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.794\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.763\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.855\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.890\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.388\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.752\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.910\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.973\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 25: 100%|██████████| 403/403 [02:11<00:00,  3.06it/s, loss=14.5957]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000102  loss: 15.0949 (15.5044)  loss_mal: 0.4397 (0.4979)  loss_bbox: 0.1776 (0.1823)  loss_giou: 0.1781 (0.1989)  loss_fgl: 0.9158 (0.9361)  loss_mal_aux_0: 0.5532 (0.6205)  loss_bbox_aux_0: 0.2239 (0.2155)  loss_giou_aux_0: 0.2150 (0.2352)  loss_fgl_aux_0: 1.0114 (1.0341)  loss_ddf_aux_0: 0.0824 (0.0980)  loss_mal_aux_1: 0.5029 (0.5214)  loss_bbox_aux_1: 0.1803 (0.1851)  loss_giou_aux_1: 0.1778 (0.2016)  loss_fgl_aux_1: 0.9219 (0.9412)  loss_ddf_aux_1: 0.0041 (0.0058)  loss_mal_pre: 0.5527 (0.6194)  loss_bbox_pre: 0.2209 (0.2154)  loss_giou_pre: 0.2126 (0.2340)  loss_mal_enc_0: 0.7065 (0.7400)  loss_bbox_enc_0: 0.3126 (0.3399)  loss_giou_enc_0: 0.3516 (0.3541)  loss_mal_dn_0: 0.5728 (0.5794)  loss_bbox_dn_0: 0.2594 (0.2565)  loss_giou_dn_0: 0.2726 (0.2908)  loss_fgl_dn_0: 1.1166 (1.1354)  loss_ddf_dn_0: 0.2172 (0.2345)  loss_mal_dn_1: 0.4268 (0.4347)  loss_bbox_dn_1: 0.1902 (0.1765)  loss_giou_dn_1: 0.1827 (0.1992)  loss_fgl_dn_1: 0.9353 (0.9464)  loss_ddf_dn_1: 0.0104 (0.0127)  loss_mal_dn_2: 0.4238 (0.4252)  loss_bbox_dn_2: 0.1761 (0.1700)  loss_giou_dn_2: 0.1774 (0.1930)  loss_fgl_dn_2: 0.9205 (0.9351)  loss_mal_dn_pre: 0.5708 (0.5789)  loss_bbox_dn_pre: 0.2630 (0.2666)  loss_giou_dn_pre: 0.2764 (0.2931)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  7.13it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.769\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.946\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.890\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.327\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.564\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.795\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.763\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.855\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.891\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.400\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.750\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.911\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.973\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 18:20:00.781\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:20:00.783\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 25 / mAP: 0.7687191752041744\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:20:00.783\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 25, 'coco_eval_bbox': 0.7687191752041744}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:20:00.784\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 26/30\u001b[0m\n",
+      "Epoch 26: 100%|██████████| 403/403 [02:04<00:00,  3.23it/s, loss=14.1053]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 15.6638 (15.4831)  loss_mal: 0.5107 (0.5072)  loss_bbox: 0.2028 (0.1816)  loss_giou: 0.1984 (0.1945)  loss_fgl: 0.9281 (0.9373)  loss_mal_aux_0: 0.5947 (0.6186)  loss_bbox_aux_0: 0.2007 (0.2146)  loss_giou_aux_0: 0.2312 (0.2300)  loss_fgl_aux_0: 1.0253 (1.0287)  loss_ddf_aux_0: 0.0793 (0.0971)  loss_mal_aux_1: 0.5532 (0.5343)  loss_bbox_aux_1: 0.2083 (0.1844)  loss_giou_aux_1: 0.2074 (0.1968)  loss_fgl_aux_1: 0.9309 (0.9423)  loss_ddf_aux_1: 0.0052 (0.0054)  loss_mal_pre: 0.5942 (0.6177)  loss_bbox_pre: 0.1973 (0.2132)  loss_giou_pre: 0.2281 (0.2286)  loss_mal_enc_0: 0.6943 (0.7392)  loss_bbox_enc_0: 0.3580 (0.3401)  loss_giou_enc_0: 0.3530 (0.3556)  loss_mal_dn_0: 0.5703 (0.5776)  loss_bbox_dn_0: 0.2975 (0.2575)  loss_giou_dn_0: 0.2828 (0.2883)  loss_fgl_dn_0: 1.1257 (1.1326)  loss_ddf_dn_0: 0.2417 (0.2408)  loss_mal_dn_1: 0.4458 (0.4331)  loss_bbox_dn_1: 0.2072 (0.1773)  loss_giou_dn_1: 0.1989 (0.1967)  loss_fgl_dn_1: 0.9502 (0.9432)  loss_ddf_dn_1: 0.0107 (0.0123)  loss_mal_dn_2: 0.4290 (0.4238)  loss_bbox_dn_2: 0.2061 (0.1710)  loss_giou_dn_2: 0.1942 (0.1907)  loss_fgl_dn_2: 0.9334 (0.9323)  loss_mal_dn_pre: 0.5703 (0.5772)  loss_bbox_dn_pre: 0.2767 (0.2700)  loss_giou_dn_pre: 0.2838 (0.2913)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.38it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.769\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.947\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.887\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.327\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.565\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.796\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.763\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.854\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.892\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.400\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.750\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.912\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.971\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 18:22:10.614\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:22:10.617\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 26 / mAP: 0.7692159995316057\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:22:10.617\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 26, 'coco_eval_bbox': 0.7692159995316057}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:22:10.618\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 27/30\u001b[0m\n",
+      "Epoch 27: 100%|██████████| 403/403 [01:49<00:00,  3.69it/s, loss=10.2263]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 11.0875 (12.6126)  loss_mal: 0.2998 (0.3610)  loss_bbox: 0.0931 (0.1255)  loss_giou: 0.1094 (0.1398)  loss_fgl: 0.7901 (0.8499)  loss_mal_aux_0: 0.3774 (0.4418)  loss_bbox_aux_0: 0.1159 (0.1445)  loss_giou_aux_0: 0.1213 (0.1594)  loss_fgl_aux_0: 0.8490 (0.9228)  loss_ddf_aux_0: 0.0585 (0.0678)  loss_mal_aux_1: 0.3318 (0.3751)  loss_bbox_aux_1: 0.0945 (0.1267)  loss_giou_aux_1: 0.1090 (0.1411)  loss_fgl_aux_1: 0.7931 (0.8541)  loss_ddf_aux_1: 0.0032 (0.0041)  loss_mal_pre: 0.3782 (0.4399)  loss_bbox_pre: 0.1121 (0.1434)  loss_giou_pre: 0.1198 (0.1581)  loss_mal_enc_0: 0.5278 (0.5666)  loss_bbox_enc_0: 0.2310 (0.2380)  loss_giou_enc_0: 0.2195 (0.2461)  loss_mal_dn_0: 0.4692 (0.5013)  loss_bbox_dn_0: 0.1766 (0.2022)  loss_giou_dn_0: 0.1900 (0.2180)  loss_fgl_dn_0: 1.0226 (1.0631)  loss_ddf_dn_0: 0.2271 (0.2397)  loss_mal_dn_1: 0.3064 (0.3521)  loss_bbox_dn_1: 0.0984 (0.1298)  loss_giou_dn_1: 0.1090 (0.1445)  loss_fgl_dn_1: 0.7893 (0.8589)  loss_ddf_dn_1: 0.0097 (0.0109)  loss_mal_dn_2: 0.3003 (0.3433)  loss_bbox_dn_2: 0.0929 (0.1248)  loss_giou_dn_2: 0.1070 (0.1402)  loss_fgl_dn_2: 0.7820 (0.8476)  loss_mal_dn_pre: 0.4690 (0.5007)  loss_bbox_dn_pre: 0.1911 (0.2102)  loss_giou_dn_pre: 0.1915 (0.2196)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:05<00:00,  6.76it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.771\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.948\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.888\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.327\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.566\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.798\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.763\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.855\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.893\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.388\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.758\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.913\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.971\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 18:24:05.653\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:24:05.655\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 27 / mAP: 0.7712160144962259\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:24:05.656\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 27, 'coco_eval_bbox': 0.7712160144962259}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:24:05.657\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 28/30\u001b[0m\n",
+      "Epoch 28: 100%|██████████| 403/403 [01:47<00:00,  3.76it/s, loss=10.3213]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 10.9653 (11.6966)  loss_mal: 0.2903 (0.3181)  loss_bbox: 0.0851 (0.1064)  loss_giou: 0.1068 (0.1216)  loss_fgl: 0.7573 (0.7998)  loss_mal_aux_0: 0.3787 (0.4125)  loss_bbox_aux_0: 0.1081 (0.1254)  loss_giou_aux_0: 0.1223 (0.1410)  loss_fgl_aux_0: 0.8300 (0.8753)  loss_ddf_aux_0: 0.0658 (0.0666)  loss_mal_aux_1: 0.2920 (0.3346)  loss_bbox_aux_1: 0.0884 (0.1077)  loss_giou_aux_1: 0.1083 (0.1229)  loss_fgl_aux_1: 0.7543 (0.8044)  loss_ddf_aux_1: 0.0031 (0.0039)  loss_mal_pre: 0.3804 (0.4100)  loss_bbox_pre: 0.1080 (0.1236)  loss_giou_pre: 0.1213 (0.1393)  loss_mal_enc_0: 0.5166 (0.5293)  loss_bbox_enc_0: 0.1851 (0.2146)  loss_giou_enc_0: 0.2142 (0.2251)  loss_mal_dn_0: 0.4568 (0.4756)  loss_bbox_dn_0: 0.1748 (0.1809)  loss_giou_dn_0: 0.1852 (0.1974)  loss_fgl_dn_0: 1.0016 (1.0287)  loss_ddf_dn_0: 0.2860 (0.2567)  loss_mal_dn_1: 0.3083 (0.3209)  loss_bbox_dn_1: 0.0957 (0.1105)  loss_giou_dn_1: 0.1107 (0.1255)  loss_fgl_dn_1: 0.7436 (0.8087)  loss_ddf_dn_1: 0.0106 (0.0105)  loss_mal_dn_2: 0.2976 (0.3117)  loss_bbox_dn_2: 0.0872 (0.1060)  loss_giou_dn_2: 0.1046 (0.1216)  loss_fgl_dn_2: 0.7281 (0.7972)  loss_mal_dn_pre: 0.4556 (0.4749)  loss_bbox_dn_pre: 0.1807 (0.1887)  loss_giou_dn_pre: 0.1872 (0.1992)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.47it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.06s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.772\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.948\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.889\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.327\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.571\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.798\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.764\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.859\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.894\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.388\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.752\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.915\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.971\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 18:25:58.162\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36m_save_checkpoint\u001b[0m:\u001b[36m613\u001b[0m - \u001b[1mCheckpoint saved to outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:25:58.164\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m505\u001b[0m - \u001b[1m🏆 NEW BEST MODEL! Epoch 28 / mAP: 0.7720694526660966\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:25:58.165\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 28, 'coco_eval_bbox': 0.7720694526660966}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:25:58.165\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m422\u001b[0m - \u001b[1mEpoch 29/30\u001b[0m\n",
+      "Epoch 29: 100%|██████████| 403/403 [01:48<00:00,  3.73it/s, loss=9.2544] \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: lr: 0.000100  loss: 10.4902 (10.9455)  loss_mal: 0.2487 (0.2864)  loss_bbox: 0.0794 (0.0930)  loss_giou: 0.0939 (0.1073)  loss_fgl: 0.7135 (0.7532)  loss_mal_aux_0: 0.3640 (0.3684)  loss_bbox_aux_0: 0.1028 (0.1109)  loss_giou_aux_0: 0.1131 (0.1255)  loss_fgl_aux_0: 0.8141 (0.8284)  loss_ddf_aux_0: 0.0611 (0.0684)  loss_mal_aux_1: 0.2761 (0.3004)  loss_bbox_aux_1: 0.0931 (0.0941)  loss_giou_aux_1: 0.0939 (0.1082)  loss_fgl_aux_1: 0.7181 (0.7567)  loss_ddf_aux_1: 0.0027 (0.0036)  loss_mal_pre: 0.3582 (0.3658)  loss_bbox_pre: 0.0999 (0.1095)  loss_giou_pre: 0.1094 (0.1240)  loss_mal_enc_0: 0.4788 (0.4994)  loss_bbox_enc_0: 0.1968 (0.1950)  loss_giou_enc_0: 0.2101 (0.2087)  loss_mal_dn_0: 0.4468 (0.4582)  loss_bbox_dn_0: 0.1557 (0.1676)  loss_giou_dn_0: 0.1760 (0.1841)  loss_fgl_dn_0: 0.9921 (1.0023)  loss_ddf_dn_0: 0.2587 (0.2848)  loss_mal_dn_1: 0.2805 (0.2968)  loss_bbox_dn_1: 0.0931 (0.0983)  loss_giou_dn_1: 0.0979 (0.1118)  loss_fgl_dn_1: 0.7409 (0.7630)  loss_ddf_dn_1: 0.0092 (0.0111)  loss_mal_dn_2: 0.2651 (0.2875)  loss_bbox_dn_2: 0.0857 (0.0941)  loss_giou_dn_2: 0.0921 (0.1080)  loss_fgl_dn_2: 0.7312 (0.7514)  loss_mal_dn_pre: 0.4507 (0.4576)  loss_bbox_dn_pre: 0.1681 (0.1760)  loss_giou_dn_pre: 0.1803 (0.1861)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 36/36 [00:04<00:00,  7.22it/s]\n",
+      "\u001b[32m2025-04-03 18:27:51.265\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1m✅ Current best stats: {'epoch': 28, 'coco_eval_bbox': 0.7720694526660966}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:27:51.265\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m555\u001b[0m - \u001b[1mTraining completed in 1:15:51\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:27:51.266\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.trainer\u001b[0m:\u001b[36mfit\u001b[0m:\u001b[36m556\u001b[0m - \u001b[1mBest stats: {'epoch': 28, 'coco_eval_bbox': 0.7720694526660966}\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Averaged stats: \n",
+      "Accumulating evaluation results...\n",
+      "COCOeval_opt.accumulate() finished...\n",
+      "DONE (t=0.07s).\n",
+      "IoU metric: bbox\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.768\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.942\n",
+      " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.884\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.328\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.576\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.794\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.764\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.859\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.894\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.388\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.763\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.913\n",
+      " Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.988\n",
+      " Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.971\n"
+     ]
+    }
+   ],
+   "source": [
+    "from deimkit import Config, Trainer, configure_dataset, configure_model\n",
+    "\n",
+    "conf = Config.from_model_name(\"deim_hgnetv2_s\")\n",
+    "\n",
+    "conf = configure_model(conf, num_queries=100, freeze_at=0, pretrained=True)\n",
+    "\n",
+    "conf = configure_dataset(\n",
+    "    config=conf,\n",
+    "    image_size=(640, 640),\n",
+    "    train_ann_file=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train/_annotations.coco.json\",\n",
+    "    train_img_folder=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train\",\n",
+    "    val_ann_file=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid/_annotations.coco.json\",\n",
+    "    val_img_folder=\"/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid\",\n",
+    "    train_batch_size=16,\n",
+    "    val_batch_size=16,\n",
+    "    num_classes=4,\n",
+    "    output_dir=\"./outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px\",\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(conf)\n",
+    "\n",
+    "trainer.fit(epochs=30, save_best_only=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2025-04-03 18:31:06.060\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mto_onnx\u001b[0m:\u001b[36m123\u001b[0m - \u001b[1mUsing device: cpu\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:06.060\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mto_onnx\u001b[0m:\u001b[36m126\u001b[0m - \u001b[1mLoading checkpoint from /home/dnth/Desktop/DEIMKit/nbs/outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:06.284\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mto_onnx\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mUsing EMA weights for model export\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:06.419\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mto_onnx\u001b[0m:\u001b[36m162\u001b[0m - \u001b[1mInput shape not provided, getting size from config\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:06.419\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mto_onnx\u001b[0m:\u001b[36m188\u001b[0m - \u001b[1mUsing target shape from config: (1, 3, 640, 640)\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:06.420\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m32\u001b[0m - \u001b[1mInitialized PreprocessingModule with target size: (640, 640)\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:06.420\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mto_onnx\u001b[0m:\u001b[36m201\u001b[0m - \u001b[1mIncluding preprocessing steps in the ONNX model.\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:06.430\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mto_onnx\u001b[0m:\u001b[36m260\u001b[0m - \u001b[1mUsing input names: ['input_bgr', 'orig_target_sizes']\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:06.431\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mto_onnx\u001b[0m:\u001b[36m261\u001b[0m - \u001b[1mUsing output names: ['labels', 'boxes', 'scores']\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:06.431\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mto_onnx\u001b[0m:\u001b[36m262\u001b[0m - \u001b[1mUsing dynamic axes: {'input_bgr': {0: 'N', 2: 'H', 3: 'W'}, 'orig_target_sizes': {0: 'N'}, 'labels': {0: 'N'}, 'boxes': {0: 'N'}, 'scores': {0: 'N'}}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:06.431\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mto_onnx\u001b[0m:\u001b[36m263\u001b[0m - \u001b[1mExporting model to ONNX: /home/dnth/Desktop/DEIMKit/nbs/outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.onnx\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:06.443\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mforward\u001b[0m:\u001b[36m54\u001b[0m - \u001b[34m\u001b[1mPreprocessing: Resized shape: torch.Size([1, 3, 640, 640])\u001b[0m\n",
+      "/home/dnth/Desktop/DEIMKit/src/deimkit/exporter.py:58: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!\n",
+      "  if x.shape[1] != 3:\n",
+      "\u001b[32m2025-04-03 18:31:06.448\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mforward\u001b[0m:\u001b[36m62\u001b[0m - \u001b[34m\u001b[1mPreprocessing: Swapped BGR to RGB\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:06.449\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mforward\u001b[0m:\u001b[36m67\u001b[0m - \u001b[34m\u001b[1mPreprocessing: Normalized pixel values to [0, 1]\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded stage1 B0 HGNetV2 from local file.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/dnth/Desktop/DEIMKit/src/deimkit/engine/deim/dfine_decoder.py:646: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!\n",
+      "  if memory.shape[0] > 1:\n",
+      "/home/dnth/Desktop/DEIMKit/src/deimkit/engine/deim/dfine_decoder.py:129: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!\n",
+      "  if reference_points.shape[-1] == 2:\n",
+      "/home/dnth/Desktop/DEIMKit/src/deimkit/engine/deim/dfine_decoder.py:133: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!\n",
+      "  elif reference_points.shape[-1] == 4:\n",
+      "/home/dnth/Desktop/DEIMKit/.pixi/envs/cuda/lib/python3.11/site-packages/torch/onnx/_internal/jit_utils.py:308: UserWarning: Constant folding - Only steps=1 can be constant folded for opset >= 10 onnx::Slice op. Constant folding not applied. (Triggered internally at /pytorch/torch/csrc/jit/passes/onnx/constant_fold.cpp:178.)\n",
+      "  _C._jit_pass_onnx_node_shape_type_inference(node, params_dict, opset_version)\n",
+      "/home/dnth/Desktop/DEIMKit/.pixi/envs/cuda/lib/python3.11/site-packages/torch/onnx/utils.py:657: UserWarning: Constant folding - Only steps=1 can be constant folded for opset >= 10 onnx::Slice op. Constant folding not applied. (Triggered internally at /pytorch/torch/csrc/jit/passes/onnx/constant_fold.cpp:178.)\n",
+      "  _C._jit_pass_onnx_graph_shape_type_inference(\n",
+      "/home/dnth/Desktop/DEIMKit/.pixi/envs/cuda/lib/python3.11/site-packages/torch/onnx/utils.py:1127: UserWarning: Constant folding - Only steps=1 can be constant folded for opset >= 10 onnx::Slice op. Constant folding not applied. (Triggered internally at /pytorch/torch/csrc/jit/passes/onnx/constant_fold.cpp:178.)\n",
+      "  _C._jit_pass_onnx_graph_shape_type_inference(\n",
+      "\u001b[32m2025-04-03 18:31:07.853\u001b[0m | \u001b[32m\u001b[1mSUCCESS \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mto_onnx\u001b[0m:\u001b[36m285\u001b[0m - \u001b[32m\u001b[1mONNX export completed successfully: /home/dnth/Desktop/DEIMKit/nbs/outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.onnx\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:07.854\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36mto_onnx\u001b[0m:\u001b[36m296\u001b[0m - \u001b[1mSimplifying ONNX model with input shapes: {'input_bgr': torch.Size([1, 3, 640, 640]), 'orig_target_sizes': torch.Size([1, 2])}\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:07.890\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36m_simplify_onnx_model\u001b[0m:\u001b[36m401\u001b[0m - \u001b[1mSimplifying ONNX model: /home/dnth/Desktop/DEIMKit/nbs/outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.onnx -> /home/dnth/Desktop/DEIMKit/nbs/outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.onnx\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:10.010\u001b[0m | \u001b[32m\u001b[1mSUCCESS \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36m_simplify_onnx_model\u001b[0m:\u001b[36m411\u001b[0m - \u001b[32m\u001b[1mONNX model simplification successful: /home/dnth/Desktop/DEIMKit/nbs/outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.onnx\u001b[0m\n",
+      "\u001b[32m2025-04-03 18:31:10.092\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mdeimkit.exporter\u001b[0m:\u001b[36m_check_onnx_model\u001b[0m:\u001b[36m368\u001b[0m - \u001b[1mONNX model validation successful: /home/dnth/Desktop/DEIMKit/nbs/outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.onnx\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "from deimkit.exporter import Exporter\n",
+    "from deimkit.config import Config\n",
+    "\n",
+    "config = Config(\"/home/dnth/Desktop/DEIMKit/nbs/outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/config.yml\")\n",
+    "exporter = Exporter(config)\n",
+    "\n",
+    "output_path = exporter.to_onnx(\n",
+    "    checkpoint_path=\"/home/dnth/Desktop/DEIMKit/nbs/outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.pth\",\n",
+    "    output_path=\"/home/dnth/Desktop/DEIMKit/nbs/outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px/best.onnx\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],

--- a/scripts/live_inference.py
+++ b/scripts/live_inference.py
@@ -1,5 +1,6 @@
 import colorsys
 import time
+from typing import Optional
 
 import cv2
 import numpy as np
@@ -19,9 +20,26 @@ def generate_colors(num_classes):
 
 
 def draw_boxes(
-    image, labels, boxes, scores, ratio, padding, threshold=0.3, class_names=None
-):
-    """Draw bounding boxes on the image."""
+    image: np.ndarray,
+    labels: np.ndarray,
+    boxes: np.ndarray,
+    scores: np.ndarray,
+    threshold: float = 0.3,
+    class_names: Optional[list[str]] = None
+) -> np.ndarray:
+    """Draw bounding boxes on the image with detection results.
+    
+    Args:
+        image: Input image array in BGR format
+        labels: Array of class labels
+        boxes: Array of bounding box coordinates [x1, y1, x2, y2]
+        scores: Array of confidence scores
+        threshold: Minimum confidence threshold for displaying detections
+        class_names: Optional list of class names for labels
+        
+    Returns:
+        np.ndarray: Image with drawn bounding boxes in BGR format
+    """
     # Generate colors for classes
     num_classes = len(class_names) if class_names else 91
     colors = generate_colors(num_classes)
@@ -146,14 +164,14 @@ def run_inference(
 
     # Load image
     image = cv2.imread(image_path)  # Load as BGR
-    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)  # Convert BGR to RGB
     original_image = image.copy()
 
+    # Prepare input data (maintain BGR format)
     im_data = np.ascontiguousarray(
         image.transpose(2, 0, 1),  # HWC to CHW format
         dtype=np.float32,
     )
-    im_data = np.expand_dims(im_data, axis=0)  # Add batch dimension
+    im_data = np.expand_dims(im_data, axis=0)
     orig_size = np.array([[image.shape[0], image.shape[1]]], dtype=np.int64)
 
     print(f"Image frame shape: {image.shape}")
@@ -179,22 +197,17 @@ def run_inference(
         labels[0],
         boxes[0],
         scores[0],
-        1.0,  # No ratio needed since we're not resizing
-        (0, 0),  # No padding needed
         threshold=threshold,
         class_names=class_names,
     )
 
-    # Save and show result
+    # Save and show result (no color conversion needed)
     output_path = "detection_result.jpg"
-    result_bgr = cv2.cvtColor(
-        result_image, cv2.COLOR_RGB2BGR
-    )  # Convert back to BGR for OpenCV
-    cv2.imwrite(output_path, result_bgr)
+    cv2.imwrite(output_path, result_image)
     print(f"Detection complete. Result saved to {output_path}")
 
     # Display the result
-    cv2.imshow("Detection Result", result_bgr)
+    cv2.imshow("Detection Result", result_image)
     cv2.waitKey(0)
     cv2.destroyAllWindows()
 
@@ -283,14 +296,14 @@ def run_inference_webcam(
 
     try:
         while True:
-            ret, frame = cap.read()
+            ret, frame = cap.read()  # Frame is already in BGR
             if not ret:
                 print("Failed to grab frame")
                 break
 
             # Calculate FPS
             current_time = time.time()
-            if current_time - prev_time > 0:  # Avoid division by zero
+            if current_time - prev_time > 0:
                 fps_display = 1 / (current_time - prev_time)
             prev_time = current_time
 
@@ -304,22 +317,19 @@ def run_inference_webcam(
             y_offset = (640 - new_height) // 2
             x_offset = (640 - new_width) // 2
 
-            # Create model input with padding
+            # Create model input with padding (maintain BGR)
             model_input = np.zeros((640, 640, 3), dtype=np.uint8)
             model_input[
                 y_offset : y_offset + new_height, x_offset : x_offset + new_width
             ] = cv2.resize(frame, (new_width, new_height))
 
-            # Convert BGR to RGB for model input
-            image = cv2.cvtColor(model_input, cv2.COLOR_BGR2RGB)
-
             # Prepare input data
             im_data = np.ascontiguousarray(
-                image.transpose(2, 0, 1),
+                model_input.transpose(2, 0, 1),
                 dtype=np.float32,
             )
             im_data = np.expand_dims(im_data, axis=0)
-            orig_size = np.array([[640, 640]], dtype=np.int64)  # Use padded size
+            orig_size = np.array([[640, 640]], dtype=np.int64)
 
             # Get input name and run inference
             input_name = session.get_inputs()[0].name
@@ -338,18 +348,13 @@ def run_inference_webcam(
 
             # Draw bounding boxes on the original frame
             result_image = draw_boxes(
-                frame,  # Use original frame
+                frame,  # Use original frame (BGR)
                 labels[0],
                 boxes,
                 scores[0],
-                1.0,  # No additional scaling needed
-                (0, 0),  # No additional padding needed
                 threshold=threshold,
                 class_names=class_names,
             )
-
-            # No need to convert back to BGR since we're using the original frame
-            result_bgr = result_image
 
             # Add video width display at top left with dark green background
             width_text = f"Width: {int(actual_width)}px"
@@ -357,7 +362,7 @@ def run_inference_webcam(
             
             # Draw dark green background rectangle
             cv2.rectangle(
-                result_bgr,
+                result_image,
                 (5, 5),  # Slight padding from corner
                 (text_size[0] + 15, 35),  # Add padding around text
                 (0, 100, 0),  # Dark green in BGR
@@ -366,7 +371,7 @@ def run_inference_webcam(
 
             # Draw text
             cv2.putText(
-                result_bgr,
+                result_image,
                 width_text,
                 (10, 30),
                 cv2.FONT_HERSHEY_SIMPLEX,
@@ -378,12 +383,12 @@ def run_inference_webcam(
             # Add FPS display (existing code)
             fps_text = f"FPS: {fps_display:.1f}"
             text_size = cv2.getTextSize(fps_text, cv2.FONT_HERSHEY_SIMPLEX, 0.8, 2)[0]
-            text_x = result_bgr.shape[1] - text_size[0] - 10
+            text_x = result_image.shape[1] - text_size[0] - 10
             text_y = 30
 
             # Draw FPS background rectangle
             cv2.rectangle(
-                result_bgr,
+                result_image,
                 (text_x - 5, text_y - text_size[1] - 5),
                 (text_x + text_size[0] + 5, text_y + 5),
                 (139, 0, 0),
@@ -392,7 +397,7 @@ def run_inference_webcam(
 
             # Draw FPS text
             cv2.putText(
-                result_bgr,
+                result_image,
                 fps_text,
                 (text_x, text_y),
                 cv2.FONT_HERSHEY_SIMPLEX,
@@ -406,21 +411,21 @@ def run_inference_webcam(
             text_size = cv2.getTextSize(
                 provider_text, cv2.FONT_HERSHEY_SIMPLEX, 0.8, 2
             )[0]
-            text_x = (result_bgr.shape[1] - text_size[0]) // 2
-            text_y = result_bgr.shape[0] - 20
+            text_x = (result_image.shape[1] - text_size[0]) // 2
+            text_y = result_image.shape[0] - 20
 
             # Draw provider background rectangle
             cv2.rectangle(
-                result_bgr,
+                result_image,
                 (text_x - 5, text_y - text_size[1] - 5),
                 (text_x + text_size[0] + 5, text_y + 5),
-                (0, 0, 139),
+                (139, 0, 0),
                 -1,
             )
 
             # Draw provider text
             cv2.putText(
-                result_bgr,
+                result_image,
                 provider_text,
                 (text_x, text_y),
                 cv2.FONT_HERSHEY_SIMPLEX,
@@ -430,7 +435,7 @@ def run_inference_webcam(
             )
 
             # Display the result
-            cv2.imshow("Webcam Detection", result_bgr)
+            cv2.imshow("Webcam Detection", result_image)
 
             # Handle key presses
             key = cv2.waitKey(1) & 0xFF
@@ -529,7 +534,7 @@ def run_inference_video(
 
     try:
         while cap.isOpened():
-            ret, frame = cap.read()
+            ret, frame = cap.read()  # Frame is already in BGR
             if not ret:
                 break
 
@@ -544,7 +549,7 @@ def run_inference_video(
                 fps_display = 1 / (current_time - prev_time)
             prev_time = current_time
 
-            # Calculate scaling and padding using video_width parameter
+            # Calculate scaling and padding
             height, width = frame.shape[:2]
             scale = video_width / max(height, width)
             new_height = int(height * scale)
@@ -554,24 +559,19 @@ def run_inference_video(
             y_offset = (video_width - new_height) // 2
             x_offset = (video_width - new_width) // 2
 
-            # Create model input with padding using video_width
+            # Create model input with padding (maintain BGR)
             model_input = np.zeros((video_width, video_width, 3), dtype=np.uint8)
             model_input[
                 y_offset : y_offset + new_height, x_offset : x_offset + new_width
             ] = cv2.resize(frame, (new_width, new_height))
 
-            # Convert BGR to RGB for model input
-            image = cv2.cvtColor(model_input, cv2.COLOR_BGR2RGB)
-
             # Prepare input data
             im_data = np.ascontiguousarray(
-                image.transpose(2, 0, 1),
+                model_input.transpose(2, 0, 1),
                 dtype=np.float32,
             )
             im_data = np.expand_dims(im_data, axis=0)
-            orig_size = np.array(
-                [[video_width, video_width]], dtype=np.int64
-            )  # Use padded size
+            orig_size = np.array([[video_width, video_width]], dtype=np.int64)
 
             # Run inference
             input_name = session.get_inputs()[0].name
@@ -590,17 +590,15 @@ def run_inference_video(
 
             # Draw bounding boxes on the original frame
             result_image = draw_boxes(
-                frame,  # Use original frame
+                frame,  # Use original frame (BGR)
                 labels[0],
                 boxes,
                 scores[0],
-                1.0,  # No additional scaling needed
-                (0, 0),  # No additional padding needed
                 threshold=threshold,
                 class_names=class_names,
             )
 
-            # Before writing the frame, resize it
+            # Resize and write frame (no color conversion needed)
             result_image = cv2.resize(result_image, (output_width, output_height))
             out.write(result_image)
 

--- a/scripts/live_inference.py
+++ b/scripts/live_inference.py
@@ -173,7 +173,7 @@ def run_inference(
     class_names_path: str | None = None,
     threshold: float = 0.3,
     provider: str = "cpu",
-    video_width: int = 640,
+    inference_size: int = 640,  # renamed from video_width
 ) -> None:
     """Run object detection on images or video streams.
     
@@ -183,7 +183,7 @@ def run_inference(
         class_names_path: Optional path to class names file
         threshold: Detection confidence threshold
         provider: ONNXRuntime provider ("cpu", "cuda", "tensorrt")
-        video_width: Width to resize video input (preserves aspect ratio)
+        inference_size: Size for inference processing (default: 640). Larger dimension will be scaled to this size while preserving aspect ratio
     """
     # Load model and class names
     session = load_model(model_path, provider)
@@ -211,7 +211,7 @@ def run_inference(
             session,
             class_names,
             threshold,
-            video_width
+            inference_size
         )
         
         # Save and display result
@@ -232,9 +232,9 @@ def run_inference(
         # Configure video capture
         if isinstance(input_source, int):  # Webcam settings
             cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc("M", "J", "P", "G"))
-            cap.set(cv2.CAP_PROP_FPS, 100)  # Large value to request max FPS for the camera
-            cap.set(cv2.CAP_PROP_FRAME_WIDTH, video_width)
-            cap.set(cv2.CAP_PROP_FRAME_HEIGHT, int(video_width * 9 / 16))
+            cap.set(cv2.CAP_PROP_FPS, 100)
+            cap.set(cv2.CAP_PROP_FRAME_WIDTH, inference_size)
+            cap.set(cv2.CAP_PROP_FRAME_HEIGHT, int(inference_size * 9 / 16))
 
         prev_time = time.time()
         fps_display = 0
@@ -257,7 +257,7 @@ def run_inference(
                     session,
                     class_names,
                     threshold,
-                    video_width
+                    inference_size
                 )
 
                 # Add overlay
@@ -265,7 +265,7 @@ def run_inference(
                     result,
                     fps_display,
                     session.get_providers()[0],
-                    video_width,
+                    inference_size,
                     show_overlay
                 )
 
@@ -465,10 +465,10 @@ if __name__ == "__main__":
     parser.add_argument("--image", type=str, help="Path to input image (optional)")
     parser.add_argument("--webcam", action="store_true", help="Use webcam input")
     parser.add_argument(
-        "--video-width",
+        "--inference-size",
         type=int,
         default=640,
-        help="Width of the video input in pixels (default: 640). Height will be adjusted to maintain aspect ratio",
+        help="Size for inference processing (default: 640). Larger dimension will be scaled to this size while preserving aspect ratio",
     )
     parser.add_argument(
         "--classes", type=str, help="Path to class names file (optional)"
@@ -492,7 +492,7 @@ if __name__ == "__main__":
 
     if args.webcam:
         run_inference(
-            args.model, 0, args.classes, args.threshold, args.provider, args.video_width
+            args.model, 0, args.classes, args.threshold, args.provider, args.inference_size
         )
     elif args.video:
         run_inference(
@@ -501,11 +501,11 @@ if __name__ == "__main__":
             args.classes,
             args.threshold,
             args.provider,
-            args.video_width,
+            args.inference_size,
         )
     elif args.image:
         run_inference(
-            args.model, args.image, args.classes, args.threshold, args.provider, args.video_width
+            args.model, args.image, args.classes, args.threshold, args.provider, args.inference_size
         )
     else:
         parser.error("Either --image, --video, or --webcam must be specified")

--- a/scripts/live_inference.py
+++ b/scripts/live_inference.py
@@ -25,10 +25,10 @@ def draw_boxes(
     boxes: np.ndarray,
     scores: np.ndarray,
     threshold: float = 0.3,
-    class_names: Optional[list[str]] = None
+    class_names: Optional[list[str]] = None,
 ) -> np.ndarray:
     """Draw bounding boxes on the image with detection results.
-    
+
     Args:
         image: Input image array in BGR format
         labels: Array of class labels
@@ -36,7 +36,7 @@ def draw_boxes(
         scores: Array of confidence scores
         threshold: Minimum confidence threshold for displaying detections
         class_names: Optional list of class names for labels
-        
+
     Returns:
         np.ndarray: Image with drawn bounding boxes in BGR format
     """
@@ -110,10 +110,20 @@ def draw_boxes(
     return image
 
 
-def run_inference(
-    model_path, image_path, class_names_path=None, threshold=0.3, provider="cpu"
-):
-    # Set up providers based on selection
+def load_model(model_path: str, provider: str = "cpu") -> ort.InferenceSession:
+    """Initialize and load the ONNX model with specified provider.
+
+    Args:
+        model_path: Path to the ONNX model file
+        provider: Provider to use for inference ("cpu", "cuda", or "tensorrt")
+
+    Returns:
+        ort.InferenceSession: Initialized ONNX Runtime session
+
+    Raises:
+        RuntimeError: If model loading fails with specified provider
+    """
+    
     if provider == "cpu":
         providers = ["CPUExecutionProvider"]
     elif provider == "cuda":
@@ -134,7 +144,7 @@ def run_inference(
             (
                 "TensorrtExecutionProvider",
                 {
-                    "trt_fp16_enable": True,
+                    "trt_fp16_enable": False,
                     "trt_engine_cache_enable": True,
                     "trt_engine_cache_path": "./trt_cache",
                     "trt_timing_cache_enable": True,
@@ -142,17 +152,41 @@ def run_inference(
             ),
             "CPUExecutionProvider",
         ]
+    else:
+        raise ValueError(f"Unsupported provider: {provider}")
 
     try:
         print(f"Loading ONNX model with providers: {providers}...")
         session = ort.InferenceSession(model_path, providers=providers)
         print(f"Using provider: {session.get_providers()[0]}")
+        return session
     except Exception as e:
         print(f"Error creating inference session with providers {providers}: {e}")
         print("Attempting to fall back to CPU execution...")
         session = ort.InferenceSession(model_path, providers=["CPUExecutionProvider"])
+        return session
 
-    # Load class names if provided
+
+def run_inference(
+    model_path: str,
+    input_source: str | int,  # Can be image path, video path, or camera index
+    class_names_path: str | None = None,
+    threshold: float = 0.3,
+    provider: str = "cpu",
+    video_width: int = 640,
+) -> None:
+    """Run object detection on images or video streams.
+    
+    Args:
+        model_path: Path to the ONNX model file
+        input_source: Path to image/video file or camera index (usually 0 for webcam)
+        class_names_path: Optional path to class names file
+        threshold: Detection confidence threshold
+        provider: ONNXRuntime provider ("cpu", "cuda", "tensorrt")
+        video_width: Width to resize video input (preserves aspect ratio)
+    """
+    # Load model and class names
+    session = load_model(model_path, provider)
     class_names = None
     if class_names_path:
         try:
@@ -162,25 +196,140 @@ def run_inference(
         except Exception as e:
             print(f"Error loading class names: {e}")
 
-    # Load image
-    image = cv2.imread(image_path)  # Load as BGR
-    original_image = image.copy()
+    # Determine if input is image file or video source
+    if isinstance(input_source, str) and any(
+        input_source.lower().endswith(ext) 
+        for ext in ['.jpg', '.jpeg', '.png', '.bmp']
+    ):
+        # Handle single image
+        image = cv2.imread(input_source)
+        if image is None:
+            raise RuntimeError(f"Failed to load image: {input_source}")
+            
+        result = process_frame(
+            image,
+            session,
+            class_names,
+            threshold,
+            video_width
+        )
+        
+        # Save and display result
+        output_path = "detection_result.jpg"
+        cv2.imwrite(output_path, result)
+        print(f"Detection complete. Result saved to {output_path}")
+        
+        cv2.imshow("Detection Result", result)
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
+        
+    else:
+        # Handle video/webcam
+        cap = cv2.VideoCapture(input_source)
+        if not cap.isOpened():
+            raise RuntimeError(f"Failed to open video source: {input_source}")
 
-    # Prepare input data (maintain BGR format)
+        # Configure video capture
+        if isinstance(input_source, int):  # Webcam settings
+            cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc("M", "J", "P", "G"))
+            cap.set(cv2.CAP_PROP_FPS, 100)  # Large value to request max FPS for the camera
+            cap.set(cv2.CAP_PROP_FRAME_WIDTH, video_width)
+            cap.set(cv2.CAP_PROP_FRAME_HEIGHT, int(video_width * 9 / 16))
+
+        prev_time = time.time()
+        fps_display = 0
+        show_overlay = True
+
+        try:
+            while True:
+                ret, frame = cap.read()
+                if not ret:
+                    break
+
+                # Calculate FPS
+                current_time = time.time()
+                fps_display = 1 / (current_time - prev_time) if current_time - prev_time > 0 else 0
+                prev_time = current_time
+
+                # Process frame
+                result = process_frame(
+                    frame,
+                    session,
+                    class_names,
+                    threshold,
+                    video_width
+                )
+
+                # Add overlay
+                result = draw_text_overlay(
+                    result,
+                    fps_display,
+                    session.get_providers()[0],
+                    video_width,
+                    show_overlay
+                )
+
+                # Display result
+                cv2.imshow("Detection", result)
+
+                # Handle key presses
+                key = cv2.waitKey(1) & 0xFF
+                if key == ord("q"):
+                    break
+                elif key == ord("t"):
+                    show_overlay = not show_overlay
+
+        finally:
+            cap.release()
+            cv2.destroyAllWindows()
+
+
+def process_frame(
+    frame: np.ndarray,
+    session: ort.InferenceSession,
+    class_names: list[str] | None,
+    threshold: float,
+    target_width: int,
+) -> np.ndarray:
+    """Process a single frame through the object detection model.
+    
+    Args:
+        frame: Input frame in BGR format
+        session: ONNX Runtime inference session
+        class_names: Optional list of class names
+        threshold: Detection confidence threshold
+        target_width: Target width for processing
+        
+    Returns:
+        np.ndarray: Processed frame with detections
+    """
+    # Calculate scaling and padding
+    height, width = frame.shape[:2]
+    scale = target_width / max(height, width)
+    new_height = int(height * scale)
+    new_width = int(width * scale)
+
+    # Calculate padding
+    y_offset = (target_width - new_height) // 2
+    x_offset = (target_width - new_width) // 2
+
+    # Create model input with padding
+    model_input = np.zeros((target_width, target_width, 3), dtype=np.uint8)
+    model_input[
+        y_offset : y_offset + new_height,
+        x_offset : x_offset + new_width
+    ] = cv2.resize(frame, (new_width, new_height))
+
+    # Prepare input data
     im_data = np.ascontiguousarray(
-        image.transpose(2, 0, 1),  # HWC to CHW format
+        model_input.transpose(2, 0, 1),
         dtype=np.float32,
     )
     im_data = np.expand_dims(im_data, axis=0)
-    orig_size = np.array([[image.shape[0], image.shape[1]]], dtype=np.int64)
-
-    print(f"Image frame shape: {image.shape}")
-    print(f"Processed input shape: {im_data.shape}")
-
-    # Get input name from model metadata
-    input_name = session.get_inputs()[0].name
+    orig_size = np.array([[target_width, target_width]], dtype=np.int64)
 
     # Run inference
+    input_name = session.get_inputs()[0].name
     outputs = session.run(
         output_names=None,
         input_feed={input_name: im_data, "orig_target_sizes": orig_size},
@@ -188,508 +337,122 @@ def run_inference(
 
     # Process outputs
     labels, boxes, scores = outputs
+    
+    # Scale boxes back to original frame size
+    boxes = boxes[0]  # Remove batch dimension
+    boxes[:, [0, 2]] = (boxes[:, [0, 2]] - x_offset) / scale  # x coordinates
+    boxes[:, [1, 3]] = (boxes[:, [1, 3]] - y_offset) / scale  # y coordinates
 
-    # print(outputs)
-
-    # Draw bounding boxes on the image
-    result_image = draw_boxes(
-        original_image,
+    # Draw detections
+    return draw_boxes(
+        frame,
         labels[0],
-        boxes[0],
+        boxes,
         scores[0],
         threshold=threshold,
         class_names=class_names,
     )
 
-    # Save and show result (no color conversion needed)
-    output_path = "detection_result.jpg"
-    cv2.imwrite(output_path, result_image)
-    print(f"Detection complete. Result saved to {output_path}")
 
-    # Display the result
-    cv2.imshow("Detection Result", result_image)
-    cv2.waitKey(0)
-    cv2.destroyAllWindows()
+def draw_text_overlay(
+    image: np.ndarray,
+    fps: float,
+    provider: str,
+    video_width: int,
+    show_overlay: bool = True,
+) -> np.ndarray:
+    """Draw text overlays (FPS, width, provider) on the detection frame.
+    
+    Args:
+        image: Input image array in BGR format
+        fps: Current FPS value to display
+        provider: Provider name being used
+        video_width: Current video width in pixels
+        show_overlay: Whether to show the text overlay
+        
+    Returns:
+        np.ndarray: Image with text overlays
+    """
+    if not show_overlay:
+        return image
 
-    return result_image
+    # Add video width display at top left with dark green background
+    width_text = f"Width: {int(video_width)}px"
+    text_size = cv2.getTextSize(width_text, cv2.FONT_HERSHEY_SIMPLEX, 0.8, 2)[0]
 
-
-def run_inference_webcam(
-    model_path, class_names_path=None, provider="cpu", threshold=0.3, video_width=640
-):
-    """Run real-time object detection on webcam feed."""
-    # Set up providers based on selection
-    if provider == "cpu":
-        providers = ["CPUExecutionProvider"]
-    elif provider == "cuda":
-        providers = [
-            (
-                "CUDAExecutionProvider",
-                {
-                    "arena_extend_strategy": "kNextPowerOfTwo",
-                    "gpu_mem_limit": 2 * 1024 * 1024 * 1024,
-                    "cudnn_conv_algo_search": "EXHAUSTIVE",
-                    "do_copy_in_default_stream": True,
-                },
-            ),
-            "CPUExecutionProvider",
-        ]
-    elif provider == "tensorrt":
-        providers = [
-            (
-                "TensorrtExecutionProvider",
-                {
-                    "trt_fp16_enable": False,
-                    "trt_engine_cache_enable": True,
-                    "trt_engine_cache_path": "./trt_cache",
-                    "trt_timing_cache_enable": True,
-                },
-            ),
-            "CPUExecutionProvider",
-        ]
-
-    try:
-        print(f"Loading ONNX model with providers: {providers}...")
-        session = ort.InferenceSession(model_path, providers=providers)
-        print(f"Using provider: {session.get_providers()[0]}")
-    except Exception as e:
-        print(f"Error creating inference session with providers {providers}: {e}")
-        print("Attempting to fall back to CPU execution...")
-        session = ort.InferenceSession(model_path, providers=["CPUExecutionProvider"])
-
-    # Update FPS calculation variables
-    prev_time = time.time()
-    fps_display = 0
-
-    # Load class names if provided
-    class_names = None
-    if class_names_path:
-        try:
-            with open(class_names_path, "r") as f:
-                class_names = [line.strip() for line in f.readlines()]
-            print(f"Loaded {len(class_names)} class names")
-        except Exception as e:
-            print(f"Error loading class names: {e}")
-
-    # Initialize webcam
-    cap = cv2.VideoCapture(0)
-    if not cap.isOpened():
-        raise RuntimeError("Failed to open webcam")
-
-    # Set camera to maximum possible FPS
-    cap.set(
-        cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc("M", "J", "P", "G")
-    )  # Use MJPG format for higher FPS
-    cap.set(
-        cv2.CAP_PROP_FPS, 1000
-    )  # Request very high FPS - will default to max supported
-    cap.set(cv2.CAP_PROP_FRAME_WIDTH, video_width)
-    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, int(video_width * 9 / 16))  # 16:9 aspect ratio
-
-    # Print actual camera properties
-    actual_fps = cap.get(cv2.CAP_PROP_FPS)
-    actual_width = cap.get(cv2.CAP_PROP_FRAME_WIDTH)
-    actual_height = cap.get(cv2.CAP_PROP_FRAME_HEIGHT)
-    print(
-        f"Camera settings - FPS: {actual_fps}, Resolution: {actual_width}x{actual_height}"
+    # Draw dark green background rectangle
+    cv2.rectangle(
+        image,
+        (5, 5),  # Slight padding from corner
+        (text_size[0] + 15, 35),  # Add padding around text
+        (0, 100, 0),  # Dark green in BGR
+        -1,  # Filled rectangle
     )
 
-    try:
-        while True:
-            ret, frame = cap.read()  # Frame is already in BGR
-            if not ret:
-                print("Failed to grab frame")
-                break
+    # Draw width text
+    cv2.putText(
+        image,
+        width_text,
+        (10, 30),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.8,
+        (255, 255, 255),  # White text
+        2,
+    )
 
-            # Calculate FPS
-            current_time = time.time()
-            if current_time - prev_time > 0:
-                fps_display = 1 / (current_time - prev_time)
-            prev_time = current_time
+    # Add FPS display
+    fps_text = f"FPS: {fps:.1f}"
+    text_size = cv2.getTextSize(fps_text, cv2.FONT_HERSHEY_SIMPLEX, 0.8, 2)[0]
+    text_x = image.shape[1] - text_size[0] - 10
+    text_y = 30
 
-            # Calculate scaling and padding
-            height, width = frame.shape[:2]
-            scale = 640.0 / max(height, width)
-            new_height = int(height * scale)
-            new_width = int(width * scale)
+    # Draw FPS background rectangle
+    cv2.rectangle(
+        image,
+        (text_x - 5, text_y - text_size[1] - 5),
+        (text_x + text_size[0] + 5, text_y + 5),
+        (139, 0, 0),
+        -1,
+    )
 
-            # Calculate padding
-            y_offset = (640 - new_height) // 2
-            x_offset = (640 - new_width) // 2
+    # Draw FPS text
+    cv2.putText(
+        image,
+        fps_text,
+        (text_x, text_y),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.8,
+        (255, 255, 255),
+        2,
+    )
 
-            # Create model input with padding (maintain BGR)
-            model_input = np.zeros((640, 640, 3), dtype=np.uint8)
-            model_input[
-                y_offset : y_offset + new_height, x_offset : x_offset + new_width
-            ] = cv2.resize(frame, (new_width, new_height))
+    # Add provider display
+    provider_text = f"Provider: {provider}"
+    text_size = cv2.getTextSize(provider_text, cv2.FONT_HERSHEY_SIMPLEX, 0.8, 2)[0]
+    text_x = (image.shape[1] - text_size[0]) // 2
+    text_y = image.shape[0] - 20
 
-            # Prepare input data
-            im_data = np.ascontiguousarray(
-                model_input.transpose(2, 0, 1),
-                dtype=np.float32,
-            )
-            im_data = np.expand_dims(im_data, axis=0)
-            orig_size = np.array([[640, 640]], dtype=np.int64)
+    # Draw provider background rectangle
+    cv2.rectangle(
+        image,
+        (text_x - 5, text_y - text_size[1] - 5),
+        (text_x + text_size[0] + 5, text_y + 5),
+        (0, 0, 139),
+        -1,
+    )
 
-            # Get input name and run inference
-            input_name = session.get_inputs()[0].name
-            outputs = session.run(
-                output_names=None,
-                input_feed={input_name: im_data, "orig_target_sizes": orig_size},
-            )
+    # Draw provider text
+    cv2.putText(
+        image,
+        provider_text,
+        (text_x, text_y),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.8,
+        (255, 255, 255),
+        2,
+    )
 
-            # Process outputs
-            labels, boxes, scores = outputs
-
-            # Scale boxes from padded 640x640 to original frame size
-            boxes = boxes[0]  # Remove batch dimension
-            boxes[:, [0, 2]] = (boxes[:, [0, 2]] - x_offset) / scale  # x coordinates
-            boxes[:, [1, 3]] = (boxes[:, [1, 3]] - y_offset) / scale  # y coordinates
-
-            # Draw bounding boxes on the original frame
-            result_image = draw_boxes(
-                frame,  # Use original frame (BGR)
-                labels[0],
-                boxes,
-                scores[0],
-                threshold=threshold,
-                class_names=class_names,
-            )
-
-            # Add video width display at top left with dark green background
-            width_text = f"Width: {int(actual_width)}px"
-            text_size = cv2.getTextSize(width_text, cv2.FONT_HERSHEY_SIMPLEX, 0.8, 2)[0]
-            
-            # Draw dark green background rectangle
-            cv2.rectangle(
-                result_image,
-                (5, 5),  # Slight padding from corner
-                (text_size[0] + 15, 35),  # Add padding around text
-                (0, 100, 0),  # Dark green in BGR
-                -1,  # Filled rectangle
-            )
-
-            # Draw text
-            cv2.putText(
-                result_image,
-                width_text,
-                (10, 30),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.8,
-                (255, 255, 255),  # White text
-                2,
-            )
-
-            # Add FPS display (existing code)
-            fps_text = f"FPS: {fps_display:.1f}"
-            text_size = cv2.getTextSize(fps_text, cv2.FONT_HERSHEY_SIMPLEX, 0.8, 2)[0]
-            text_x = result_image.shape[1] - text_size[0] - 10
-            text_y = 30
-
-            # Draw FPS background rectangle
-            cv2.rectangle(
-                result_image,
-                (text_x - 5, text_y - text_size[1] - 5),
-                (text_x + text_size[0] + 5, text_y + 5),
-                (139, 0, 0),
-                -1,
-            )
-
-            # Draw FPS text
-            cv2.putText(
-                result_image,
-                fps_text,
-                (text_x, text_y),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.8,
-                (255, 255, 255),
-                2,
-            )
-
-            # Add provider display
-            provider_text = f"Provider: {session.get_providers()[0]}"
-            text_size = cv2.getTextSize(
-                provider_text, cv2.FONT_HERSHEY_SIMPLEX, 0.8, 2
-            )[0]
-            text_x = (result_image.shape[1] - text_size[0]) // 2
-            text_y = result_image.shape[0] - 20
-
-            # Draw provider background rectangle
-            cv2.rectangle(
-                result_image,
-                (text_x - 5, text_y - text_size[1] - 5),
-                (text_x + text_size[0] + 5, text_y + 5),
-                (139, 0, 0),
-                -1,
-            )
-
-            # Draw provider text
-            cv2.putText(
-                result_image,
-                provider_text,
-                (text_x, text_y),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.8,
-                (255, 255, 255),
-                2,
-            )
-
-            # Display the result
-            cv2.imshow("Webcam Detection", result_image)
-
-            # Handle key presses
-            key = cv2.waitKey(1) & 0xFF
-            if key == ord("q"):
-                break
-
-    finally:
-        cap.release()
-        cv2.destroyAllWindows()
-
-
-def run_inference_video(
-    model_path,
-    video_path,
-    class_names_path=None,
-    provider="cpu",
-    threshold=0.3,
-    video_width=640,
-):
-    """Run object detection on a video file."""
-    # Set up providers (same as webcam function)
-    if provider == "cpu":
-        providers = ["CPUExecutionProvider"]
-    elif provider == "cuda":
-        providers = [
-            (
-                "CUDAExecutionProvider",
-                {
-                    "arena_extend_strategy": "kNextPowerOfTwo",
-                    "gpu_mem_limit": 2 * 1024 * 1024 * 1024,
-                    "cudnn_conv_algo_search": "EXHAUSTIVE",
-                    "do_copy_in_default_stream": True,
-                },
-            ),
-            "CPUExecutionProvider",
-        ]
-    elif provider == "tensorrt":
-        providers = [
-            (
-                "TensorrtExecutionProvider",
-                {
-                    "trt_fp16_enable": False,
-                    "trt_engine_cache_enable": True,
-                    "trt_engine_cache_path": "./trt_cache",
-                    "trt_timing_cache_enable": True,
-                },
-            ),
-            "CPUExecutionProvider",
-        ]
-
-    # Initialize model session
-    try:
-        print(f"Loading ONNX model with providers: {providers}...")
-        session = ort.InferenceSession(model_path, providers=providers)
-        print(f"Using provider: {session.get_providers()[0]}")
-    except Exception as e:
-        print(f"Error creating inference session with providers {providers}: {e}")
-        print("Attempting to fall back to CPU execution...")
-        session = ort.InferenceSession(model_path, providers=["CPUExecutionProvider"])
-
-    # Load class names
-    class_names = None
-    if class_names_path:
-        try:
-            with open(class_names_path, "r") as f:
-                class_names = [line.strip() for line in f.readlines()]
-            print(f"Loaded {len(class_names)} class names")
-        except Exception as e:
-            print(f"Error loading class names: {e}")
-
-    # Open video file
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
-        raise RuntimeError(f"Failed to open video file: {video_path}")
-
-    # Get video properties
-    fps = int(cap.get(cv2.CAP_PROP_FPS))
-    frame_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    frame_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-
-    # Calculate output dimensions based on video_width
-    scale = video_width / frame_width
-    output_width = video_width
-    output_height = int(frame_height * scale)
-
-    # Create video writer with new dimensions
-    output_path = "detection_output.mp4"
-    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
-    out = cv2.VideoWriter(output_path, fourcc, fps, (output_width, output_height))
-
-    # Initialize FPS calculation
-    prev_time = time.time()
-    fps_display = 0
-    frame_count = 0
-
-    try:
-        while cap.isOpened():
-            ret, frame = cap.read()  # Frame is already in BGR
-            if not ret:
-                break
-
-            frame_count += 1
-            if frame_count % 10 == 0:
-                progress = (frame_count / total_frames) * 100
-                print(f"Processing: {progress:.1f}% complete", end="\r")
-
-            # Calculate FPS
-            current_time = time.time()
-            if current_time - prev_time > 0:
-                fps_display = 1 / (current_time - prev_time)
-            prev_time = current_time
-
-            # Calculate scaling and padding
-            height, width = frame.shape[:2]
-            scale = video_width / max(height, width)
-            new_height = int(height * scale)
-            new_width = int(width * scale)
-
-            # Calculate padding
-            y_offset = (video_width - new_height) // 2
-            x_offset = (video_width - new_width) // 2
-
-            # Create model input with padding (maintain BGR)
-            model_input = np.zeros((video_width, video_width, 3), dtype=np.uint8)
-            model_input[
-                y_offset : y_offset + new_height, x_offset : x_offset + new_width
-            ] = cv2.resize(frame, (new_width, new_height))
-
-            # Prepare input data
-            im_data = np.ascontiguousarray(
-                model_input.transpose(2, 0, 1),
-                dtype=np.float32,
-            )
-            im_data = np.expand_dims(im_data, axis=0)
-            orig_size = np.array([[video_width, video_width]], dtype=np.int64)
-
-            # Run inference
-            input_name = session.get_inputs()[0].name
-            outputs = session.run(
-                output_names=None,
-                input_feed={input_name: im_data, "orig_target_sizes": orig_size},
-            )
-
-            # Process outputs
-            labels, boxes, scores = outputs
-
-            # Scale boxes from padded 640x640 to original frame size
-            boxes = boxes[0]  # Remove batch dimension
-            boxes[:, [0, 2]] = (boxes[:, [0, 2]] - x_offset) / scale  # x coordinates
-            boxes[:, [1, 3]] = (boxes[:, [1, 3]] - y_offset) / scale  # y coordinates
-
-            # Draw bounding boxes on the original frame
-            result_image = draw_boxes(
-                frame,  # Use original frame (BGR)
-                labels[0],
-                boxes,
-                scores[0],
-                threshold=threshold,
-                class_names=class_names,
-            )
-
-            # Resize and write frame (no color conversion needed)
-            result_image = cv2.resize(result_image, (output_width, output_height))
-            out.write(result_image)
-
-            # Add video width display at top left with dark green background
-            width_text = f"Width: {output_width}px"
-            text_size = cv2.getTextSize(width_text, cv2.FONT_HERSHEY_SIMPLEX, 0.8, 2)[0]
-            
-            # Draw dark green background rectangle
-            cv2.rectangle(
-                result_image,
-                (5, 5),  # Slight padding from corner
-                (text_size[0] + 15, 35),  # Add padding around text
-                (0, 100, 0),  # Dark green in BGR
-                -1,  # Filled rectangle
-            )
-
-            # Draw text
-            cv2.putText(
-                result_image,
-                width_text,
-                (10, 30),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.8,
-                (255, 255, 255),  # White text
-                2,
-            )
-
-            # Add FPS counter and provider info (existing code)
-            fps_text = f"FPS: {fps_display:.1f}"
-            text_size = cv2.getTextSize(fps_text, cv2.FONT_HERSHEY_SIMPLEX, 0.8, 2)[0]
-            text_x = result_image.shape[1] - text_size[0] - 10
-            text_y = 30
-
-            # Draw FPS background rectangle
-            cv2.rectangle(
-                result_image,
-                (text_x - 5, text_y - text_size[1] - 5),
-                (text_x + text_size[0] + 5, text_y + 5),
-                (139, 0, 0),
-                -1,
-            )
-
-            # Draw FPS text
-            cv2.putText(
-                result_image,
-                fps_text,
-                (text_x, text_y),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.8,
-                (255, 255, 255),
-                2,
-            )
-
-            # Add provider display at bottom (matching webcam style)
-            provider_text = f"Provider: {session.get_providers()[0]}"
-            text_size = cv2.getTextSize(
-                provider_text, cv2.FONT_HERSHEY_SIMPLEX, 0.8, 2
-            )[0]
-            text_x = (result_image.shape[1] - text_size[0]) // 2
-            text_y = result_image.shape[0] - 20
-
-            # Draw provider background rectangle
-            cv2.rectangle(
-                result_image,
-                (text_x - 5, text_y - text_size[1] - 5),
-                (text_x + text_size[0] + 5, text_y + 5),
-                (139, 0, 0),
-                -1,
-            )
-
-            # Draw provider text
-            cv2.putText(
-                result_image,
-                provider_text,
-                (text_x, text_y),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.8,
-                (255, 255, 255),
-                2,
-            )
-
-            # Display frame (optional)
-            cv2.imshow("Video Detection", result_image)
-            if cv2.waitKey(1) & 0xFF == ord("q"):
-                break
-
-    finally:
-        cap.release()
-        out.release()
-        cv2.destroyAllWindows()
-        print(f"\nVideo processing complete. Output saved to {output_path}")
+    return image
 
 
 if __name__ == "__main__":
@@ -728,21 +491,21 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.webcam:
-        run_inference_webcam(
-            args.model, args.classes, args.provider, args.threshold, args.video_width
+        run_inference(
+            args.model, 0, args.classes, args.threshold, args.provider, args.video_width
         )
     elif args.video:
-        run_inference_video(
+        run_inference(
             args.model,
             args.video,
             args.classes,
-            args.provider,
             args.threshold,
+            args.provider,
             args.video_width,
         )
     elif args.image:
         run_inference(
-            args.model, args.image, args.classes, args.threshold, args.provider
+            args.model, args.image, args.classes, args.threshold, args.provider, args.video_width
         )
     else:
         parser.error("Either --image, --video, or --webcam must be specified")

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -6,18 +6,19 @@ conf = configure_model(conf, num_queries=100, freeze_at=0, pretrained=True)
 
 conf = configure_dataset(
     config=conf,
-    image_size=(640, 640),
+    image_size=(800, 800),
     train_ann_file="/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train/_annotations.coco.json",
     train_img_folder="/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/train",
     val_ann_file="/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid/_annotations.coco.json",
     val_img_folder="/home/dnth/Desktop/DEIMKit/dataset_collections/Rock Paper Scissors SXSW.v14i.coco/valid",
-    train_batch_size=20,
-    val_batch_size=20,
+    train_batch_size=16,
+    val_batch_size=16,
     num_classes=4,
     remap_mscoco=False,
-    output_dir="./outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_num_queries_pinto",
+    output_dir="./outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_num_queries_resume_3",
 )
 
 trainer = Trainer(conf)
 
-trainer.fit(epochs=30, save_best_only=True)
+trainer.load_checkpoint("/home/dnth/Desktop/DEIMKit/outputs/rock-paper-scissors/deim_hgnetv2_s_30ep_640px_num_queries_resume_2/best.pth")
+trainer.fit(epochs=10, save_best_only=True, lr=0.00004)


### PR DESCRIPTION
This PR includes several improvements to parameter naming and training capabilities:

Key Changes:
- Renamed `--video-width` parameter to `--inference-size` in live inference scripts for better clarity and consistency
- Added progressive resizing training strategy with notebook demonstration
- Updated training script configurations for improved batch handling
- Enhanced checkpoint loading with better error handling for image size mismatches

The parameter renaming provides more intuitive configuration options for users, while the progressive resizing strategy allows for more efficient training workflows. The checkpoint loading improvements make the system more robust when handling models trained with different configurations.

Testing:
- Verified parameter changes in live inference scripts
- Tested progressive resizing strategy with 128px initial size
- Validated checkpoint loading with mismatched configurations